### PR TITLE
Add  JPA and MySQL dependencies and Create member JPA entity

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -23,7 +23,10 @@ repositories {
 
 dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-web'
+	implementation "org.springframework.boot:spring-boot-starter-data-jpa:3.1.2"
 	implementation 'org.springframework.boot:spring-boot-starter-security'
+	implementation 'mysql:mysql-connector-java:8.0.28' 
+
 	compileOnly 'org.projectlombok:lombok'
 	annotationProcessor 'org.projectlombok:lombok'
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'

--- a/src/main/java/mogakco/StudyManagement/entity/Member.java
+++ b/src/main/java/mogakco/StudyManagement/entity/Member.java
@@ -1,0 +1,49 @@
+package mogakco.StudyManagement.entity;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import mogakco.StudyManagement.enums.MemberRole;
+
+@Entity
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+@Getter
+@Table(name = "member")
+public class Member {
+
+  @Id
+  @GeneratedValue(strategy = GenerationType.IDENTITY)
+  private Long memberId;
+
+  @Column(nullable = false, unique = true)
+  private String id;
+
+  @Column(nullable = false)
+  private String password;
+
+  @Column(nullable = false)
+  private String name;
+
+  @Column(nullable = false)
+  private String contact;
+
+  @Column(nullable = false)
+  private MemberRole role;
+
+  @Column(nullable = false)
+  private String createdAt;
+
+  @Column(nullable = false)
+  private String updatedAt;
+
+  private String expiredAt;
+}

--- a/src/main/java/mogakco/StudyManagement/enums/MemberRole.java
+++ b/src/main/java/mogakco/StudyManagement/enums/MemberRole.java
@@ -1,0 +1,6 @@
+package mogakco.StudyManagement.enums;
+
+public enum MemberRole {
+  ADMIN,
+  MANAGER,
+}

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,1 +1,8 @@
 
+spring.jpa.show-sql=true
+spring.jpa.hibernate.ddl-auto=update
+
+spring.datasource.driver-class-name=com.mysql.cj.jdbc.Driver
+spring.datasource.url: jdbc:mysql://localhost:3307/study
+spring.datasource.username=mysql
+spring.datasource.password=mysql123!


### PR DESCRIPTION
안녕하세요 @dayeon-dayeon @MeMyself-And-I  😚


 > @dayeon-dayeon
- JPA와 MySQL 의존성이 빠져 있어 이를 추가하였고, 설정 파일에 DB 접속에 필요한 설정들을 추가하였습니다!
- 로그인 기능 구현을 위해 member entity를 우선 생성하였습니다! 확인 부탁 드립니다!
<img width="586" alt="image" src="https://github.com/ZinnaChoi/Study-Management/assets/142554606/ee496be3-30ee-42f8-aa31-5667f69a7350">


> @MeMyself-And-I 
 - Role의 경우 MANAGER, ADMIN enum 값으로 설정 해두었습니다 원하는 대로 변경해서 사용하시면 됩니다 : )
 -  API 개발 시 참고 부탁 드립니다!


