### PR TITLE
[feat] setting Security & Swagger configs

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -23,9 +23,13 @@ repositories {
 
 dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-web'
-	implementation "org.springframework.boot:spring-boot-starter-data-jpa:3.1.2"
+	implementation 'org.springframework.boot:spring-boot-starter-data-jpa:3.1.2'
 	implementation 'org.springframework.boot:spring-boot-starter-security'
+	implementation 'io.jsonwebtoken:jjwt-api:0.12.3'
+    implementation 'io.jsonwebtoken:jjwt-impl:0.12.3'
+    implementation 'io.jsonwebtoken:jjwt-jackson:0.12.3'
 	implementation 'mysql:mysql-connector-java:8.0.28' 
+	implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.2.0'
 
 	compileOnly 'org.projectlombok:lombok'
 	annotationProcessor 'org.projectlombok:lombok'

--- a/src/main/java/mogakco/StudyManagement/config/AdminAccount.java
+++ b/src/main/java/mogakco/StudyManagement/config/AdminAccount.java
@@ -1,0 +1,48 @@
+package mogakco.StudyManagement.config;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+import org.springframework.stereotype.Component;
+
+import jakarta.annotation.PostConstruct;
+import mogakco.StudyManagement.entity.Member;
+import mogakco.StudyManagement.enums.MemberRole;
+import mogakco.StudyManagement.repository.MemberRepository;
+
+@Component
+public class AdminAccount {
+
+    @Value("${account.admin.id}")
+    private String adminId;
+
+    @Value("${account.admin.password}")
+    private String password;
+
+    private final MemberRepository memberRepository;
+    private final BCryptPasswordEncoder bCryptPasswordEncoder;
+
+    public AdminAccount(MemberRepository memberRepository, BCryptPasswordEncoder bCryptPasswordEncoder) {
+        this.memberRepository = memberRepository;
+        this.bCryptPasswordEncoder = bCryptPasswordEncoder;
+    }
+
+    // 최초 ADMIN 계정 생성
+    @PostConstruct
+    private void createAdminAccount() {
+
+        if (!memberRepository.existsById(adminId)) {
+            Member member = Member.builder()
+                    .id("admin")
+                    .password(bCryptPasswordEncoder.encode(password))
+                    .name("관리자")
+                    .contact("")
+                    .role(MemberRole.ADMIN)
+                    .createdAt("000000000000000")
+                    .updatedAt("000000000000000")
+                    .build();
+
+            memberRepository.save(member);
+        }
+    }
+
+}

--- a/src/main/java/mogakco/StudyManagement/config/SecurityConfig.java
+++ b/src/main/java/mogakco/StudyManagement/config/SecurityConfig.java
@@ -1,0 +1,62 @@
+package mogakco.StudyManagement.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.authentication.AuthenticationManager;
+import org.springframework.security.config.annotation.authentication.configuration.AuthenticationConfiguration;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.config.http.SessionCreationPolicy;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
+
+import mogakco.StudyManagement.jwt.JWTFilter;
+import mogakco.StudyManagement.jwt.JWTUtil;
+
+@Configuration
+@EnableWebSecurity
+public class SecurityConfig {
+
+    private final JWTUtil jwtUtil;
+
+    public SecurityConfig(JWTUtil jwtUtil) {
+        this.jwtUtil = jwtUtil;
+    }
+
+    @Bean
+    public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
+        // csrf disable -> 세션 인증 방식이 아닌 jwt 방식에서는 필요 없음
+        http.csrf((auth) -> auth.disable());
+        // form 로그인 방식(default 방식) disable -> jwt 방식이므로
+        http.formLogin((auth) -> auth.disable());
+        // http basic 인증 방식 disable
+        http.httpBasic((auth) -> auth.disable());
+        // 경로별 인가 작업
+        http.authorizeHttpRequests((auth) -> auth
+                .requestMatchers("/", "api/v1/login", "api/v1/join", "api/v1/logout").permitAll() // 회원가입, 로그인, 로그아웃은 인증
+                                                                                                  // X
+                .requestMatchers("/v3/api-docs/**", "/swagger-ui/**", "/swagger-resources/**").permitAll() // swagger 경로
+                                                                                                           // 접근 허용
+                .requestMatchers("/api/v1/**").hasAnyAuthority("ADMIN", "USER") // 모든 권한 api/user/** 접근 가능!
+                .anyRequest().authenticated()); // 그 외 요청들은 인증된 사용자(유효한 JWT를 가지고있는)만 접근 가능
+        // 로그인 필터 전에 동작
+        http.addFilterBefore(new JWTFilter(jwtUtil), UsernamePasswordAuthenticationFilter.class);
+        // 세션 stateless 설정
+        http.sessionManagement((session) -> session
+                .sessionCreationPolicy(SessionCreationPolicy.STATELESS));
+
+        return http.build();
+    }
+
+    // AuthenticationManager Bean 등록
+    @Bean
+    public AuthenticationManager authenticationManager(AuthenticationConfiguration configuration) throws Exception {
+        return configuration.getAuthenticationManager();
+    }
+
+    @Bean
+    public BCryptPasswordEncoder bCryptPasswordEncoder() {
+        return new BCryptPasswordEncoder();
+    }
+}

--- a/src/main/java/mogakco/StudyManagement/config/SecurityConfig.java
+++ b/src/main/java/mogakco/StudyManagement/config/SecurityConfig.java
@@ -36,8 +36,9 @@ public class SecurityConfig {
         http.authorizeHttpRequests((auth) -> auth
                 .requestMatchers("/", "api/v1/login", "api/v1/join", "api/v1/logout").permitAll() // 회원가입, 로그인, 로그아웃은 인증
                                                                                                   // X
-                .requestMatchers("/v3/api-docs/**", "/swagger-ui/**", "/swagger-resources/**").permitAll() // swagger 경로
-                                                                                                           // 접근 허용
+                .requestMatchers("/swagger-ui.html", "/v1/api-docs/**", "/swagger-ui/**", "/swagger-resources/**")
+                .permitAll() // swagger 경로
+                // 접근 허용
                 .requestMatchers("/api/v1/**").hasAnyAuthority("ADMIN", "USER") // 모든 권한 api/user/** 접근 가능!
                 .anyRequest().authenticated()); // 그 외 요청들은 인증된 사용자(유효한 JWT를 가지고있는)만 접근 가능
         // 로그인 필터 전에 동작

--- a/src/main/java/mogakco/StudyManagement/config/SwaggerConfig.java
+++ b/src/main/java/mogakco/StudyManagement/config/SwaggerConfig.java
@@ -1,0 +1,29 @@
+package mogakco.StudyManagement.config;
+
+import io.swagger.v3.oas.models.Components;
+import io.swagger.v3.oas.models.OpenAPI;
+import io.swagger.v3.oas.models.info.Info;
+import io.swagger.v3.oas.models.security.SecurityScheme;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class SwaggerConfig {
+    @Bean
+    public OpenAPI openAPI() {
+        return new OpenAPI()
+                .components(new Components()
+                        .addSecuritySchemes("bearer-key",
+                                new SecurityScheme().type(SecurityScheme.Type.HTTP).scheme("bearer")
+                                        .bearerFormat("JWT")))
+                .info(apiInfo());
+    }
+
+    private Info apiInfo() {
+        return new Info()
+                .title("모각코 스터디 관리 API Doc")
+                .description("스터디 관리에 사용되는 API 문서입니다.")
+                .version("1.0.0");
+    }
+}

--- a/src/main/java/mogakco/StudyManagement/controller/MemberController.java
+++ b/src/main/java/mogakco/StudyManagement/controller/MemberController.java
@@ -1,0 +1,31 @@
+package mogakco.StudyManagement.controller;
+
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import mogakco.StudyManagement.domain.Login;
+import mogakco.StudyManagement.service.MemberService;
+
+@Tag(name = "계정 및 권한", description = "계정 및 권한 관련 API 분류")
+@RequestMapping(path = "/api/v1")
+@RestController
+public class MemberController {
+
+    private final MemberService memberService;
+
+    public MemberController(MemberService memberService) {
+        this.memberService = memberService;
+    }
+
+    @Operation(summary = "로그인", description = "로그인을 통해 JWT 발급")
+    @PostMapping("/login")
+    public String doLogin(@RequestBody Login loginInfo) {
+        String result = memberService.login(loginInfo);
+        return result;
+    }
+
+}

--- a/src/main/java/mogakco/StudyManagement/controller/helloController.java
+++ b/src/main/java/mogakco/StudyManagement/controller/helloController.java
@@ -3,12 +3,18 @@ package mogakco.StudyManagement.controller;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RestController;
 
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
+import io.swagger.v3.oas.annotations.tags.Tag;
+
+@Tag(name = "예제 API", description = "Swagger 테스트용 API")
 @RestController
 public class helloController {
-    
-    @GetMapping("/api/hello")
-    public String test(){
+
+    @Operation(summary = "시큐리티 및 Swagger 테스트 API", description = "1. 그낭 이 API 요청해본다, 2. login API를 통해 받은 토큰을 통해 Swagger login, 3. 다시 이 API 요청해본다")
+    @SecurityRequirement(name = "bearer-key")
+    @GetMapping("/api/v1/hello")
+    public String test() {
         return "Hello~!~~!~!!!";
     }
-    
 }

--- a/src/main/java/mogakco/StudyManagement/domain/Login.java
+++ b/src/main/java/mogakco/StudyManagement/domain/Login.java
@@ -1,0 +1,16 @@
+package mogakco.StudyManagement.domain;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+public class Login {
+
+    @Schema(example = "admin")
+    private String username;
+
+    @Schema(example = "password")
+    private String password;
+}

--- a/src/main/java/mogakco/StudyManagement/domain/MemberDetails.java
+++ b/src/main/java/mogakco/StudyManagement/domain/MemberDetails.java
@@ -1,0 +1,64 @@
+package mogakco.StudyManagement.domain;
+
+import java.util.ArrayList;
+import java.util.Collection;
+
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.userdetails.UserDetails;
+
+import mogakco.StudyManagement.entity.Member;
+
+public class MemberDetails implements UserDetails {
+
+    private final Member member;
+
+    public MemberDetails(Member member) {
+        this.member = member;
+    }
+
+    @Override
+    public Collection<? extends GrantedAuthority> getAuthorities() {
+        Collection<GrantedAuthority> collection = new ArrayList<>();
+
+        collection.add(new GrantedAuthority() {
+
+            @Override
+            public String getAuthority() {
+                return member.getRole().toString();
+            }
+
+        });
+        return collection;
+    }
+
+    @Override
+    public String getPassword() {
+        return member.getPassword();
+    }
+
+    @Override
+    public String getUsername() {
+        return member.getId();
+    }
+
+    @Override
+    public boolean isAccountNonExpired() {
+        return true;
+    }
+
+    @Override
+    public boolean isAccountNonLocked() {
+        return true;
+    }
+
+    @Override
+    public boolean isCredentialsNonExpired() {
+        return true;
+    }
+
+    @Override
+    public boolean isEnabled() {
+        return true;
+    }
+
+}

--- a/src/main/java/mogakco/StudyManagement/enums/MemberRole.java
+++ b/src/main/java/mogakco/StudyManagement/enums/MemberRole.java
@@ -2,5 +2,14 @@ package mogakco.StudyManagement.enums;
 
 public enum MemberRole {
   ADMIN,
-  USER,
+  USER;
+
+  public static MemberRole fromString(String role) {
+    for (MemberRole memberRole : MemberRole.values()) {
+      if (memberRole.name().equalsIgnoreCase(role)) {
+        return memberRole;
+      }
+    }
+    throw new IllegalArgumentException("No constant with role " + role + " found");
+  }
 }

--- a/src/main/java/mogakco/StudyManagement/jwt/JWTFilter.java
+++ b/src/main/java/mogakco/StudyManagement/jwt/JWTFilter.java
@@ -1,0 +1,75 @@
+package mogakco.StudyManagement.jwt;
+
+import java.io.IOException;
+
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import mogakco.StudyManagement.domain.MemberDetails;
+import mogakco.StudyManagement.entity.Member;
+import mogakco.StudyManagement.enums.MemberRole;
+
+// JWT 인증 및 인가 관련 필터
+public class JWTFilter extends OncePerRequestFilter {
+
+    private final JWTUtil jwtUtil;
+
+    public JWTFilter(JWTUtil jwtUtil) {
+        this.jwtUtil = jwtUtil;
+    }
+
+    @Override
+    protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain filterChain)
+            throws ServletException, IOException {
+        // request에서 Authorization 헤더를 찾음
+        String authorization = request.getHeader("Authorization");
+
+        // Authorization 헤더 검증(널이거나 RFC 7235 정의에 맞지 않는 양식이면)
+        if (authorization == null || !authorization.startsWith("Bearer ")) {
+            System.out.println("token null");
+            // 다음 필터 실행
+            filterChain.doFilter(request, response);
+            // 조건이 해당되면 메소드 종료
+            return;
+        }
+
+        System.out.println("authorization now");
+        // Bearer 부분 제거 후 순수 토큰만 획득
+        String token = authorization.split(" ")[1];
+
+        // 토큰 소멸 시간 검증
+        if (jwtUtil.isExpired(token)) {
+            System.out.println("token expired");
+            // 다음 필터 실행
+            filterChain.doFilter(request, response);
+            // 조건이 해당되면 메소드 종료
+            return;
+        }
+
+        // 토큰에서 id와 role 획득
+        String id = jwtUtil.getUserId(token);
+        MemberRole role = MemberRole.fromString(jwtUtil.getRole(token));
+
+        // member를 생성하여 값 set
+        Member member = Member.builder().id(id).role(role).build();
+
+        // UserDetails에 회원 정보 객체 담기
+        MemberDetails memberDetails = new MemberDetails(member);
+
+        // 스프링 시큐리티 인증 토큰 생성
+        Authentication authToken = new UsernamePasswordAuthenticationToken(memberDetails, null,
+                memberDetails.getAuthorities());
+
+        // 세션에 사용자 등록
+        SecurityContextHolder.getContext().setAuthentication(authToken);
+        // 다음 필터 실행
+        filterChain.doFilter(request, response);
+    }
+
+}

--- a/src/main/java/mogakco/StudyManagement/jwt/JWTUtil.java
+++ b/src/main/java/mogakco/StudyManagement/jwt/JWTUtil.java
@@ -1,0 +1,54 @@
+package mogakco.StudyManagement.jwt;
+
+import java.nio.charset.StandardCharsets;
+import java.util.Date;
+
+import javax.crypto.SecretKey;
+import javax.crypto.spec.SecretKeySpec;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+
+import io.jsonwebtoken.Jwts;
+
+@Component
+public class JWTUtil {
+    private SecretKey secretKey;
+
+    // 생성자에서 secretkey 암호화(알고리즘: HS256)
+    public JWTUtil(@Value("${jwt.secret}") String secret) {
+        secretKey = new SecretKeySpec(secret.getBytes(StandardCharsets.UTF_8),
+                Jwts.SIG.HS256.key().build().getAlgorithm());
+    }
+
+    // 토큰 내용(Payload) 인증 메소드
+    public String getUserId(String token) {
+        return Jwts.parser().verifyWith(secretKey).build().parseSignedClaims(token).getPayload().get("id",
+                String.class);
+    }
+
+    // 토큰 내용(Payload) 인증 메소드
+    public String getRole(String token) {
+        return Jwts.parser().verifyWith(secretKey).build().parseSignedClaims(token).getPayload().get("role",
+                String.class);
+    }
+
+    // 토큰 내용(Payload) 인증 메소드
+    public Boolean isExpired(String token) {
+        return Jwts.parser().verifyWith(secretKey).build().parseSignedClaims(token).getPayload().getExpiration()
+                .before(new Date());
+    }
+
+    // JWT 생성 메소드
+    public String createJwt(String id, String role, Long expiredMs) {
+
+        return Jwts.builder()
+                .claim("id", id)
+                .claim("role", role)
+                .issuedAt(new Date(System.currentTimeMillis())) // 생성 일자
+                .expiration(new Date(System.currentTimeMillis() + expiredMs)) // 만료 일자
+                .signWith(secretKey)
+                .compact();
+    }
+
+}

--- a/src/main/java/mogakco/StudyManagement/repository/MemberRepository.java
+++ b/src/main/java/mogakco/StudyManagement/repository/MemberRepository.java
@@ -1,0 +1,12 @@
+package mogakco.StudyManagement.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import mogakco.StudyManagement.entity.Member;
+
+public interface MemberRepository extends JpaRepository<Member, Long> {
+
+    Member findById(String id);
+
+    Boolean existsById(String id);
+}

--- a/src/main/java/mogakco/StudyManagement/service/MemberDetailsService.java
+++ b/src/main/java/mogakco/StudyManagement/service/MemberDetailsService.java
@@ -1,0 +1,34 @@
+package mogakco.StudyManagement.service;
+
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.security.core.userdetails.UserDetailsService;
+import org.springframework.security.core.userdetails.UsernameNotFoundException;
+import org.springframework.stereotype.Service;
+
+import mogakco.StudyManagement.domain.MemberDetails;
+import mogakco.StudyManagement.entity.Member;
+import mogakco.StudyManagement.repository.MemberRepository;
+
+@Service
+public class MemberDetailsService implements UserDetailsService {
+
+    private final MemberRepository memberRepository;
+
+    public MemberDetailsService(MemberRepository memberRepository) {
+        this.memberRepository = memberRepository;
+    }
+
+    @Override
+    public UserDetails loadUserByUsername(String username) throws UsernameNotFoundException {
+
+        Member member = memberRepository.findById(username);
+
+        if (member != null) {
+
+            return new MemberDetails(member);
+        }
+
+        return null;
+    }
+
+}

--- a/src/main/java/mogakco/StudyManagement/service/MemberService.java
+++ b/src/main/java/mogakco/StudyManagement/service/MemberService.java
@@ -1,0 +1,46 @@
+package mogakco.StudyManagement.service;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+import org.springframework.stereotype.Service;
+
+import mogakco.StudyManagement.domain.Login;
+import mogakco.StudyManagement.entity.Member;
+import mogakco.StudyManagement.jwt.JWTUtil;
+import mogakco.StudyManagement.repository.MemberRepository;
+
+@Service
+public class MemberService {
+
+    private final MemberRepository memberRepository;
+    private final BCryptPasswordEncoder bCryptPasswordEncoder;
+    private final JWTUtil jwtUtil;
+
+    @Value("${jwt.expired.time}")
+    private Long expiredTime;
+
+    public MemberService(MemberRepository memberRepository, BCryptPasswordEncoder bCryptPasswordEncoder,
+            JWTUtil jwtUtil) {
+        this.memberRepository = memberRepository;
+        this.bCryptPasswordEncoder = bCryptPasswordEncoder;
+        this.jwtUtil = jwtUtil;
+    }
+
+    public String login(Login loginInfo) {
+
+        Member member = memberRepository.findById(loginInfo.getUsername());
+
+        if (member == null) {
+            return "해당 ID로 존재하는 사용자가 없습니다.";
+        }
+
+        String targetPwd = loginInfo.getPassword();
+        String originPwd = member.getPassword();
+
+        if (!bCryptPasswordEncoder.matches(targetPwd, originPwd)) {
+            return "비밀번호가 맞지 않습니다.";
+        }
+
+        return jwtUtil.createJwt(member.getId(), member.getRole().toString(), expiredTime);
+    }
+}

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -8,5 +8,12 @@ spring.datasource.url: jdbc:mysql://localhost:3307/study
 spring.datasource.username=mysql
 spring.datasource.password=mysql123!
 
+account.admin.id=admin
+account.admin.password=password
+
+jwt.secret=mogakcostudymanagementapplication
+# 토큰 만료 시간 30분(ms 단위)
+jwt.expired.time=1800000
+
 logging.level.org.hibernate.SQL=DEBUG
 logging.level.org.hibernate.type.descriptor.sql.BasicBinder=TRACE

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -8,6 +8,11 @@ spring.datasource.url: jdbc:mysql://localhost:3307/study
 spring.datasource.username=mysql
 spring.datasource.password=mysql123!
 
+springdoc.api-docs.path=/v1/api-docs
+springdoc.swagger-ui.disable-swagger-default-url=true
+springdoc.swagger-ui.configUrl=/v1/api-docs/swagger-config
+springdoc.swagger-ui.url=/v1/api-docs
+
 account.admin.id=admin
 account.admin.password=password
 


### PR DESCRIPTION
Spring Security 및 Swagger 설정 완료했습니다.
주요 내역은 하기를 참고해주세요.

1. 권한 분리
-> 로그인, 로그아웃, 회원가입 시에는 JWT 인증 없이 요청 가능
-> 나머지 요청들은 토큰 인증이 필요하도록 구성함(빠른 작업을 위한 임시 구성으로 추후 관리자 추가 또는 기타 사유로 변경이 필요할 경우 변경 예정)

2. 로그인 API 구현 및 자동 관리자 계정 DB에 추가
-> admin 계정을 프로젝트 실행 시 자동으로 member 테이블에 추가(설정은 properties 파일을 통해 변경 가능)
-> 로그인 API 실행 후 Request Body에 발급된 JWT Return됨(나중에 frontend단 API 요청 시 헤더에 JWT 추가 필요)

3. Swagger 설정
-> maven repo 기준 가장 많이 사용하는 springdoc 2.2.0 버전 사용
-> 시큐리티 설정이 되어있기 때문에 swagger를 통해 API 요청에 필요한 swagger 설정 완료