### PR TITLE
[fix] properties change and login api return value change

### DIFF
--- a/src/main/java/mogakco/StudyManagement/config/AccountConfig.java
+++ b/src/main/java/mogakco/StudyManagement/config/AccountConfig.java
@@ -8,6 +8,7 @@ import jakarta.annotation.PostConstruct;
 import mogakco.StudyManagement.domain.Member;
 import mogakco.StudyManagement.enums.MemberRole;
 import mogakco.StudyManagement.repository.MemberRepository;
+import mogakco.StudyManagement.util.DateUtil;
 
 @Component
 public class AccountConfig {
@@ -37,8 +38,8 @@ public class AccountConfig {
                     .name("관리자")
                     .contact("")
                     .role(MemberRole.ADMIN)
-                    .createdAt("000000000000000")
-                    .updatedAt("000000000000000")
+                    .createdAt(DateUtil.getCurrentDateTime())
+                    .updatedAt(DateUtil.getCurrentDateTime())
                     .build();
 
             memberRepository.save(member);

--- a/src/main/java/mogakco/StudyManagement/controller/MemberController.java
+++ b/src/main/java/mogakco/StudyManagement/controller/MemberController.java
@@ -7,24 +7,50 @@ import org.springframework.web.bind.annotation.RestController;
 
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import mogakco.StudyManagement.dto.DTOResCommon;
 import mogakco.StudyManagement.dto.MemberLoginReq;
-import mogakco.StudyManagement.service.member.MemberService;
+import mogakco.StudyManagement.dto.MemberLoginRes;
+import mogakco.StudyManagement.enums.ErrorCode;
+import mogakco.StudyManagement.service.member.impl.MemberServiceImpl;
 
 @Tag(name = "계정 및 권한", description = "계정 및 권한 관련 API 분류")
 @RequestMapping(path = "/api/v1")
 @RestController
-public class MemberController {
+public class MemberController extends CommonController {
 
-    private final MemberService memberService;
+    private final MemberServiceImpl memberServiceImpl;
 
-    public MemberController(MemberService memberService) {
-        this.memberService = memberService;
+    public MemberController(MemberServiceImpl memberServiceImpl) {
+        this.memberServiceImpl = memberServiceImpl;
     }
 
     @Operation(summary = "로그인", description = "로그인을 통해 JWT 발급")
     @PostMapping("/login")
-    public String doLogin(@RequestBody MemberLoginReq loginInfo) {
-        String result = memberService.login(loginInfo);
+    public DTOResCommon doLogin(@RequestBody MemberLoginReq loginInfo) {
+        MemberLoginRes result = new MemberLoginRes();
+        DTOResCommon res = new DTOResCommon();
+
+        if (loginInfo.getSendDate() == null) {
+            return setResult(ErrorCode.NOT_FOUND, "sendDate");
+        }
+
+        try {
+            result = memberServiceImpl.login(loginInfo);
+            if (result.getToken().isEmpty()) {
+                res = setResult(ErrorCode.BAD_REQUEST);
+            } else {
+                res = setResult(ErrorCode.OK);
+            }
+
+            result.setRetCode(res.getRetCode());
+            result.setRetMsg(res.getRetMsg());
+            result.setSendDate(res.getSendDate());
+            result.setSystemId(res.getSystemId());
+
+        } catch (Exception e) {
+            e.printStackTrace();
+        }
+
         return result;
     }
 

--- a/src/main/java/mogakco/StudyManagement/dto/MemberLoginReq.java
+++ b/src/main/java/mogakco/StudyManagement/dto/MemberLoginReq.java
@@ -6,7 +6,7 @@ import lombok.Setter;
 
 @Getter
 @Setter
-public class MemberLoginReq {
+public class MemberLoginReq extends DTOReqCommon {
 
     @Schema(example = "admin")
     private String username;

--- a/src/main/java/mogakco/StudyManagement/dto/MemberLoginRes.java
+++ b/src/main/java/mogakco/StudyManagement/dto/MemberLoginRes.java
@@ -1,0 +1,21 @@
+package mogakco.StudyManagement.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@Setter
+@AllArgsConstructor
+@NoArgsConstructor
+public class MemberLoginRes extends DTOResCommon {
+
+    @Schema(example = "aaaaa.bbbbb.ccccc")
+    private String token;
+
+    @Schema(example = "Sueccess")
+    private String message;
+
+}

--- a/src/main/java/mogakco/StudyManagement/service/member/MemberService.java
+++ b/src/main/java/mogakco/StudyManagement/service/member/MemberService.java
@@ -4,9 +4,10 @@ import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.security.core.userdetails.UsernameNotFoundException;
 
 import mogakco.StudyManagement.dto.MemberLoginReq;
+import mogakco.StudyManagement.dto.MemberLoginRes;
 
 public interface MemberService {
     UserDetails loadUserByUsername(String username) throws UsernameNotFoundException;
 
-    String login(MemberLoginReq loginInfo);
+    MemberLoginRes login(MemberLoginReq loginInfo);
 }

--- a/src/main/java/mogakco/StudyManagement/service/member/impl/MemberServiceImpl.java
+++ b/src/main/java/mogakco/StudyManagement/service/member/impl/MemberServiceImpl.java
@@ -10,6 +10,7 @@ import org.springframework.stereotype.Service;
 import mogakco.StudyManagement.domain.Member;
 import mogakco.StudyManagement.dto.MemberDetails;
 import mogakco.StudyManagement.dto.MemberLoginReq;
+import mogakco.StudyManagement.dto.MemberLoginRes;
 import mogakco.StudyManagement.repository.MemberRepository;
 import mogakco.StudyManagement.service.member.MemberService;
 import mogakco.StudyManagement.util.JWTUtil;
@@ -41,21 +42,29 @@ public class MemberServiceImpl implements MemberService, UserDetailsService {
     }
 
     @Override
-    public String login(MemberLoginReq loginInfo) {
+    public MemberLoginRes login(MemberLoginReq loginInfo) {
 
+        MemberLoginRes response = new MemberLoginRes();
         Member member = memberRepository.findById(loginInfo.getUsername());
 
         if (member == null) {
-            return "해당 ID로 존재하는 사용자가 없습니다.";
+            response.setMessage("해당 ID로 존재하는 사용자가 없습니다.");
+            response.setToken("");
+            return response;
         }
 
         String targetPwd = loginInfo.getPassword();
         String originPwd = member.getPassword();
 
         if (!bCryptPasswordEncoder.matches(targetPwd, originPwd)) {
-            return "비밀번호가 맞지 않습니다.";
+            response.setMessage("비밀번호가 맞지 않습니다.");
+            response.setToken("");
+            return response;
         }
 
-        return jwtUtil.createJwt(member.getId(), member.getRole().toString(), expiredTime);
+        response.setMessage("Success");
+        response.setToken(jwtUtil.createJwt(member.getId(), member.getRole().toString(), expiredTime));
+
+        return response;
     }
 }

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,3 +1,4 @@
+server.port=8090
 
 spring.jpa.show-sql=true
 spring.jpa.hibernate.ddl-auto=update
@@ -16,7 +17,7 @@ springdoc.swagger-ui.url=/v1/api-docs
 account.admin.id=admin
 account.admin.password=password
 
-jwt.secret=mogakcostudymanagementapplication
+jwt.secret=NwkqmAFTauzXEOiJLxcMRHSbYDthgWCsPre
 # 토큰 만료 시간 30분(ms 단위)
 jwt.expired.time=1800000
 


### PR DESCRIPTION
수정 사항입니다.
1. admin 계정 created_at, updated_at 실제 생성 시간으로 Insert
2. 백엔드 포트 번호 지정 -> 8090
3. 프로퍼티 파일 내 jwt 시크릿 키 수정(온라인 Random String Generator)
4. 로그인 API 리턴 값 공용 도메인 형식으로 변경