### PR TITLE
Add file logging method for API logging

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@ build/
 !gradle/wrapper/gradle-wrapper.jar
 !**/src/main/**/build/
 !**/src/test/**/build/
+logs/
 
 ### STS ###
 .apt_generated

--- a/src/main/resources/logback-spring.xml
+++ b/src/main/resources/logback-spring.xml
@@ -1,14 +1,26 @@
 <configuration>
-
     <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
         <encoder>
-            <pattern>%d{yyyy-MM-dd HH:mm:ss} [%thread] %-5level %logger{36} - %msg%n</pattern>
+            <pattern>%d{yyyy-MM-dd HH:mm:ss} [%thread] %-5level %logger{0} - %msg%n</pattern>
         </encoder>
     </appender>
-
+    <appender name="FILE" class="ch.qos.logback.core.rolling.RollingFileAppender">
+        <!-- 초기 로그 파일 이름 설정 -->
+        <file>logs/logfile-today.log</file> 
+        <encoder>
+            <pattern>%d{yyyy-MM-dd HH:mm:ss} [%thread] %-5level %logger{0} - %msg%n</pattern>
+        </encoder>
+        <!-- 매일 자정 로그 파일을 그날 날짜로 저장하고, 새로운 초기 로그 파일 생성 -->
+        <rollingPolicy class="ch.qos.logback.core.rolling.TimeBasedRollingPolicy">
+            <fileNamePattern>logs/logfile-%d{yyyy-MM-dd}.log</fileNamePattern>
+            <!-- 30일 지난 로그는 삭제 -->
+            <maxHistory>30</maxHistory>
+        </rollingPolicy>
+    </appender>
     <logger name="org.springframework.web" level="INFO"/>
     <root level="INFO">
         <appender-ref ref="STDOUT"/>
+        <appender-ref ref="FILE"/>
     </root>
 
 </configuration>


### PR DESCRIPTION
@dayeon-dayeon 안녕하세요!

로그를 기존 콘솔에만 찍히던 방식에서 
=> 파일로 저장되도록 logback 파일을 수정했습니다!
파일은 하루 주기로 새로 생성되며, 30일이 지난 로그는 삭제되도록 설정해 두었습니다

파일로도, console에서도 로그를 확인하실 수 있습니다

확인 부탁드립니다 
감사합니다!