### PR TITLE
Task add post register api

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -25,6 +25,7 @@ dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-web'
 	implementation 'org.springframework.boot:spring-boot-starter-data-jpa:3.1.2'
 	implementation 'org.springframework.boot:spring-boot-starter-security'
+	implementation group: 'org.springframework.boot', name: 'spring-boot-starter-validation', version: '3.1.2'
 	implementation 'io.jsonwebtoken:jjwt-api:0.12.3'
     implementation 'io.jsonwebtoken:jjwt-impl:0.12.3'
     implementation 'io.jsonwebtoken:jjwt-jackson:0.12.3'

--- a/src/main/java/mogakco/StudyManagement/controller/PostController.java
+++ b/src/main/java/mogakco/StudyManagement/controller/PostController.java
@@ -1,0 +1,48 @@
+package mogakco.StudyManagement.controller;
+
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.validation.Valid;
+import mogakco.StudyManagement.dto.DTOResCommon;
+import mogakco.StudyManagement.dto.PostCreateReq;
+import mogakco.StudyManagement.enums.ErrorCode;
+import mogakco.StudyManagement.service.common.LoggingService;
+import mogakco.StudyManagement.service.post.PostService;
+
+@Tag(name = "게시판", description = "게시판 관련 API 분류")
+@SecurityRequirement(name = "bearer-key")
+@RequestMapping(path = "/api/v1")
+@RestController
+public class PostController extends CommonController {
+
+    private final PostService postService;
+
+    public PostController(PostService postService, LoggingService lo) {
+        super(lo);
+        this.postService = postService;
+    }
+
+    @Operation(summary = "게시글 등록", description = "새 게시글 추가")
+    @PostMapping("/posts")
+    public DTOResCommon createPost(HttpServletRequest request, @RequestBody @Valid PostCreateReq postCreateReq) {
+
+        DTOResCommon result = new DTOResCommon();
+        try {
+            startAPI(lo, postCreateReq);
+            postService.createPost(postCreateReq, lo);
+            result = setCommonResult(ErrorCode.OK, lo, DTOResCommon.class);
+        } catch (Exception e) {
+            result = setCommonResult(ErrorCode.INTERNAL_ERROR, lo, DTOResCommon.class);
+        } finally {
+            endAPI(request, ErrorCode.OK, lo, result);
+        }
+        return result;
+    }
+}

--- a/src/main/java/mogakco/StudyManagement/dto/DTOReqCommon.java
+++ b/src/main/java/mogakco/StudyManagement/dto/DTOReqCommon.java
@@ -2,6 +2,7 @@ package mogakco.StudyManagement.dto;
 
 import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 import lombok.Setter;
 
 /*
@@ -10,6 +11,7 @@ import lombok.Setter;
  */
 @Getter
 @Setter
+@NoArgsConstructor
 public class DTOReqCommon {
 
     @Schema(name = "sendDate", example = "20240112113804899")

--- a/src/main/java/mogakco/StudyManagement/dto/DTOReqCommon.java
+++ b/src/main/java/mogakco/StudyManagement/dto/DTOReqCommon.java
@@ -1,5 +1,6 @@
 package mogakco.StudyManagement.dto;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.Getter;
 import lombok.Setter;
 
@@ -11,7 +12,10 @@ import lombok.Setter;
 @Setter
 public class DTOReqCommon {
 
+    @Schema(name = "20240112113804899")
     private String sendDate;
+
+    @Schema(name = "STUDY_0001")
     private String systemId;
 
 }

--- a/src/main/java/mogakco/StudyManagement/dto/DTOReqCommon.java
+++ b/src/main/java/mogakco/StudyManagement/dto/DTOReqCommon.java
@@ -12,10 +12,15 @@ import lombok.Setter;
 @Setter
 public class DTOReqCommon {
 
-    @Schema(name = "20240112113804899")
+    @Schema(name = "sendDate", example = "20240112113804899")
     private String sendDate;
 
-    @Schema(name = "STUDY_0001")
+    @Schema(name = "systemId", example = "STUDY_0001")
     private String systemId;
+
+    public DTOReqCommon(String sendDate, String systemId) {
+        this.sendDate = sendDate;
+        this.systemId = systemId;
+    }
 
 }

--- a/src/main/java/mogakco/StudyManagement/dto/DTOResCommon.java
+++ b/src/main/java/mogakco/StudyManagement/dto/DTOResCommon.java
@@ -4,6 +4,7 @@ import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
+import mogakco.StudyManagement.util.DateUtil;
 
 /*
  * sendDate 송신 시간(yyyyMMdd24HHmmssSSS)
@@ -22,4 +23,10 @@ public class DTOResCommon {
     private Integer retCode;
     private String retMsg;
 
+    public DTOResCommon(String systemId, Integer retCode, String retMsg) {
+        this.sendDate = DateUtil.getCurrentDateTime();
+        this.setSystemId(systemId);
+        this.retCode = retCode;
+        this.retMsg = retMsg;
+    }
 }

--- a/src/main/java/mogakco/StudyManagement/dto/MemberLoginReq.java
+++ b/src/main/java/mogakco/StudyManagement/dto/MemberLoginReq.java
@@ -13,4 +13,10 @@ public class MemberLoginReq extends DTOReqCommon {
 
     @Schema(example = "password")
     private String password;
+
+    public MemberLoginReq(String sendDate, String systemId, String username, String password) {
+        super(sendDate, systemId);
+        this.username = username;
+        this.password = password;
+    }
 }

--- a/src/main/java/mogakco/StudyManagement/dto/PostCreateReq.java
+++ b/src/main/java/mogakco/StudyManagement/dto/PostCreateReq.java
@@ -4,10 +4,12 @@ import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.Pattern;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 import lombok.Setter;
 
 @Getter
 @Setter
+@NoArgsConstructor
 public class PostCreateReq extends DTOReqCommon {
 
     @NotBlank(message = "게시글의 제목은 반드시 있어야 합니다")

--- a/src/main/java/mogakco/StudyManagement/dto/PostCreateReq.java
+++ b/src/main/java/mogakco/StudyManagement/dto/PostCreateReq.java
@@ -20,4 +20,10 @@ public class PostCreateReq extends DTOReqCommon {
     @Schema(example = "chatGPT 5.0 도입")
     private String content;
 
+    public PostCreateReq(String sendDate, String systemId, String title, String content) {
+        super(sendDate, systemId);
+        this.title = title;
+        this.content = content;
+    }
+
 }

--- a/src/main/java/mogakco/StudyManagement/dto/PostCreateReq.java
+++ b/src/main/java/mogakco/StudyManagement/dto/PostCreateReq.java
@@ -1,0 +1,23 @@
+package mogakco.StudyManagement.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Pattern;
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+public class PostCreateReq extends DTOReqCommon {
+
+    @NotBlank(message = "게시글의 제목은 반드시 있어야 합니다")
+    @Pattern(regexp = "^.{1,60}$", message = "게시글의 제목은 60자 이하여야 합니다")
+    @Schema(example = "2024 2월 개발 뉴스 공유드립니다")
+    private String title;
+
+    @NotBlank(message = "게시글의 내용은 반드시 있어야 합니다")
+    @Pattern(regexp = "^.{1,20000}$", message = "게시글의 내용은 20000자 이하여야 합니다")
+    @Schema(example = "chatGPT 5.0 도입")
+    private String content;
+
+}

--- a/src/main/java/mogakco/StudyManagement/enums/ErrorCode.java
+++ b/src/main/java/mogakco/StudyManagement/enums/ErrorCode.java
@@ -24,6 +24,10 @@ public enum ErrorCode {
     private final HttpStatus httpStatus;
     private final String message;
 
+    public HttpStatus getHttpStatus() {
+        return this.httpStatus;
+    }
+
     public String getMessage(Throwable e) {
         return this.getMessage(this.getMessage() + " - " + e.getMessage());
     }

--- a/src/main/java/mogakco/StudyManagement/exception/ControllerExceptionHandler.java
+++ b/src/main/java/mogakco/StudyManagement/exception/ControllerExceptionHandler.java
@@ -1,0 +1,54 @@
+package mogakco.StudyManagement.exception;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.HttpStatusCode;
+import org.springframework.http.ResponseEntity;
+import org.springframework.http.converter.HttpMessageNotReadableException;
+import org.springframework.web.bind.MethodArgumentNotValidException;
+import org.springframework.web.bind.annotation.ControllerAdvice;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.validation.FieldError;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+
+import mogakco.StudyManagement.controller.CommonController;
+import mogakco.StudyManagement.dto.DTOResCommon;
+import mogakco.StudyManagement.enums.ErrorCode;
+import mogakco.StudyManagement.service.common.LoggingService;
+
+import java.util.HashMap;
+import java.util.Map;
+
+@ControllerAdvice
+public class ControllerExceptionHandler extends CommonController {
+
+    public ControllerExceptionHandler(LoggingService lo) {
+        super(lo);
+    }
+
+    @ExceptionHandler(MethodArgumentNotValidException.class)
+    public ResponseEntity<DTOResCommon> handleValidationExceptions(MethodArgumentNotValidException ex)
+            throws JsonProcessingException {
+        Map<String, String> errors = new HashMap<>();
+        ex.getBindingResult().getAllErrors().forEach(error -> {
+            String fieldName = ((FieldError) error).getField();
+            String errorMessage = error.getDefaultMessage();
+            errors.put(fieldName, errorMessage);
+        });
+        String errorString = mapper.writeValueAsString(errors);
+        return ResponseEntity.status(ErrorCode.BAD_REQUEST.getHttpStatus())
+                .body(new DTOResCommon(systemId, ErrorCode.BAD_REQUEST.getCode(), errorString));
+
+    }
+
+    @ExceptionHandler(HttpMessageNotReadableException.class)
+    public ResponseEntity<DTOResCommon> handleHttpMessageNotReadableException(
+            HttpMessageNotReadableException ex) {
+        String errorString = ex.getLocalizedMessage();
+        return ResponseEntity
+                .status(ErrorCode.BAD_REQUEST.getHttpStatus())
+                .body(new DTOResCommon(systemId, ErrorCode.BAD_REQUEST.getCode(), errorString));
+    }
+
+}

--- a/src/main/java/mogakco/StudyManagement/exception/ControllerExceptionHandler.java
+++ b/src/main/java/mogakco/StudyManagement/exception/ControllerExceptionHandler.java
@@ -27,6 +27,7 @@ public class ControllerExceptionHandler extends CommonController {
     @ExceptionHandler(MethodArgumentNotValidException.class)
     public ResponseEntity<DTOResCommon> handleValidationExceptions(MethodArgumentNotValidException ex)
             throws JsonProcessingException {
+
         Map<String, String> errors = new HashMap<>();
         ex.getBindingResult().getAllErrors().forEach(error -> {
             String fieldName = ((FieldError) error).getField();

--- a/src/main/java/mogakco/StudyManagement/exception/ControllerExceptionHandler.java
+++ b/src/main/java/mogakco/StudyManagement/exception/ControllerExceptionHandler.java
@@ -1,8 +1,5 @@
 package mogakco.StudyManagement.exception;
 
-import org.springframework.beans.factory.annotation.Value;
-import org.springframework.http.HttpStatus;
-import org.springframework.http.HttpStatusCode;
 import org.springframework.http.ResponseEntity;
 import org.springframework.http.converter.HttpMessageNotReadableException;
 import org.springframework.web.bind.MethodArgumentNotValidException;

--- a/src/main/java/mogakco/StudyManagement/repository/PostRepository.java
+++ b/src/main/java/mogakco/StudyManagement/repository/PostRepository.java
@@ -1,0 +1,11 @@
+package mogakco.StudyManagement.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import mogakco.StudyManagement.domain.Post;
+
+@Repository
+public interface PostRepository extends JpaRepository<Post, Long> {
+
+}

--- a/src/main/java/mogakco/StudyManagement/service/post/PostService.java
+++ b/src/main/java/mogakco/StudyManagement/service/post/PostService.java
@@ -1,0 +1,8 @@
+package mogakco.StudyManagement.service.post;
+
+import mogakco.StudyManagement.dto.PostCreateReq;
+import mogakco.StudyManagement.service.common.LoggingService;
+
+public interface PostService {
+    void createPost(PostCreateReq postCreateReq, LoggingService lo);
+}

--- a/src/main/java/mogakco/StudyManagement/service/post/impl/PostServiceImpl.java
+++ b/src/main/java/mogakco/StudyManagement/service/post/impl/PostServiceImpl.java
@@ -28,7 +28,6 @@ public class PostServiceImpl implements PostService {
         // TODO: 로그인한 스터디원 정보 가져오는 기능 구현 필요
         Member member = memberRepository.findById("admin");
 
-        // TODO: 조회수 기능 구현 필요
         Post post = Post.builder().member(member).title(postCreateReq.getTitle()).content(postCreateReq.getContent())
                 .viewCnt(0).createdAt(DateUtil.getCurrentDateTime()).updatedAt(DateUtil.getCurrentDateTime())
                 .build();

--- a/src/main/java/mogakco/StudyManagement/service/post/impl/PostServiceImpl.java
+++ b/src/main/java/mogakco/StudyManagement/service/post/impl/PostServiceImpl.java
@@ -1,0 +1,41 @@
+package mogakco.StudyManagement.service.post.impl;
+
+import org.springframework.stereotype.Service;
+
+import mogakco.StudyManagement.domain.Member;
+import mogakco.StudyManagement.domain.Post;
+import mogakco.StudyManagement.dto.PostCreateReq;
+import mogakco.StudyManagement.repository.MemberRepository;
+import mogakco.StudyManagement.repository.PostRepository;
+import mogakco.StudyManagement.service.common.LoggingService;
+import mogakco.StudyManagement.service.post.PostService;
+import mogakco.StudyManagement.util.DateUtil;
+
+@Service
+public class PostServiceImpl implements PostService {
+
+    private final MemberRepository memberRepository;
+    private final PostRepository postRepository;
+
+    public PostServiceImpl(MemberRepository memberRepository, PostRepository postRepository) {
+        this.memberRepository = memberRepository;
+        this.postRepository = postRepository;
+    }
+
+    @Override
+    public void createPost(PostCreateReq postCreateReq, LoggingService lo) {
+
+        // TODO: 로그인한 스터디원 정보 가져오는 기능 구현 필요
+        Member member = memberRepository.findById("admin");
+
+        // TODO: 조회수 기능 구현 필요
+        Post post = Post.builder().member(member).title(postCreateReq.getTitle()).content(postCreateReq.getContent())
+                .viewCnt(0).createdAt(DateUtil.getCurrentDateTime()).updatedAt(DateUtil.getCurrentDateTime())
+                .build();
+
+        lo.setDBStart();
+        postRepository.save(post);
+        lo.setDBEnd();
+    }
+
+}

--- a/src/test/java/mogakco/StudyManagement/controller/PostControllerTest.java
+++ b/src/test/java/mogakco/StudyManagement/controller/PostControllerTest.java
@@ -1,0 +1,73 @@
+package mogakco.StudyManagement.controller;
+
+import org.junit.jupiter.api.Test;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.security.test.context.support.WithMockUser;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.web.servlet.MockMvc;
+
+import mogakco.StudyManagement.dto.PostCreateReq;
+import mogakco.StudyManagement.service.common.LoggingService;
+import mogakco.StudyManagement.service.post.PostService;
+import mogakco.StudyManagement.util.DateUtil;
+import mogakco.StudyManagement.util.TestUtil;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+@ActiveProfiles("test")
+@AutoConfigureMockMvc
+@SpringBootTest
+public class PostControllerTest {
+
+    @Mock
+    private PostService postService;
+
+    @Mock
+    private LoggingService loggingService;
+
+    @InjectMocks
+    private PostController postController;
+
+    @Autowired
+    private ObjectMapper objectMapper;
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    private static final String CREATE_POST_API_URL = "/api/v1/posts";
+
+    @Test
+    @WithMockUser(authorities = "ADMIN")
+    public void createPostSuccess() throws Exception {
+        String requestBodyJson = objectMapper
+                .writeValueAsString(new PostCreateReq(DateUtil.getCurrentDateTime(), "SYS_01", "2024 2월 개발 뉴스 공유드립니다",
+                        "chatGPT 5.0 도입"));
+        TestUtil.performPostRequest(mockMvc, CREATE_POST_API_URL, requestBodyJson, 200,
+                200);
+    }
+
+    @Test
+    @WithMockUser(authorities = "ADMIN")
+    public void createPostFailEmptyTitle() throws Exception {
+        String requestBodyJson = objectMapper
+                .writeValueAsString(new PostCreateReq(DateUtil.getCurrentDateTime(), "SYS_01", null, "chatGPT 5.0 도입"));
+        TestUtil.performPostRequest(mockMvc, CREATE_POST_API_URL, requestBodyJson, 400, 400);
+    }
+
+    @Test
+    @WithMockUser(authorities = "ADMIN")
+    public void createPostFailInvalidJson() throws Exception {
+        String invalidJson = "{\n" +
+                "  \"sendDate\": \"20240112132910401\",\n" +
+                "  \"systemId\": \"SYS_01\",\n" +
+                "  \"title\": \"2024 2월 개발 뉴스 공유드립니다\",\n" +
+                "  \"content\": \"chatGPT 5.0 도입\"\n"; // Bad Request (Missing closing brace)
+
+        TestUtil.performPostRequest(mockMvc, CREATE_POST_API_URL, invalidJson, 400, 400);
+    }
+
+}

--- a/src/test/java/mogakco/StudyManagement/util/TestUtil.java
+++ b/src/test/java/mogakco/StudyManagement/util/TestUtil.java
@@ -1,0 +1,22 @@
+package mogakco.StudyManagement.util;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+
+public class TestUtil {
+
+    public static void performPostRequest(MockMvc mockMvc, String url, String requestBodyJson, int expectedStatus,
+            Integer expectedRetCode)
+            throws Exception {
+        mockMvc.perform(post(url)
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(requestBodyJson))
+                .andExpect(status().is(expectedStatus))
+                .andExpect(expectedRetCode != null ? jsonPath("$.retCode").value(expectedRetCode) : null);
+    }
+
+}


### PR DESCRIPTION
안녕하세요 @dayeon-dayeon!!

> 게시글 등록 API와 그 테스트 코드를 생성했습니다
- `PostControllerTest.java` 에서 확인 가능합니다

- API input validation은 PostCreateReq에 제약조건 어노테이션들을 추가하고(@NotBlank, @Pattern) 이를 Controller 에서 input 입력 시 @Valid 어노테이션을 통해 input이 올바른지를 확인하였습니다
```java
@RequestBody @Valid PostCreateReq postCreateReq) {
```

- 올바르지 못한 json input과 (@NotBlank, @Pattern) <- 여기서 잡은 error의 경우 `ControllerExceptionHandler.java`를 통해 공통적으로 처리하였습니다

- 또한 test 시에도 post 요청을 보내는 공통 메서드를 `testUitl.java`에 생성해두었습니다

-  아직 로그인 유저 정보를 게시글 작성자로 저장하는 로직이 미구현사항으로 남아 있는데, 이는 member쪽 API들이 어느정도 완성된 이후에 구현 예정입니다!

확인 부탁드립니다
감사합니다 😄😄
