### PR TITLE
Add post list retrieve API

### DIFF
--- a/src/main/java/mogakco/StudyManagement/controller/CommonController.java
+++ b/src/main/java/mogakco/StudyManagement/controller/CommonController.java
@@ -7,10 +7,8 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.SerializationFeature;
 
 import jakarta.servlet.http.HttpServletRequest;
-import mogakco.StudyManagement.dto.DTOResCommon;
 import mogakco.StudyManagement.enums.ErrorCode;
 import mogakco.StudyManagement.service.common.LoggingService;
-import mogakco.StudyManagement.util.DateUtil;
 
 public class CommonController {
 

--- a/src/main/java/mogakco/StudyManagement/controller/PostController.java
+++ b/src/main/java/mogakco/StudyManagement/controller/PostController.java
@@ -1,5 +1,10 @@
 package mogakco.StudyManagement.controller;
 
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
+import org.springframework.data.web.PageableDefault;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.ModelAttribute;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -12,10 +17,12 @@ import jakarta.servlet.http.HttpServletRequest;
 import jakarta.validation.Valid;
 import mogakco.StudyManagement.dto.DTOResCommon;
 import mogakco.StudyManagement.dto.PostCreateReq;
-
+import mogakco.StudyManagement.dto.PostListReq;
+import mogakco.StudyManagement.dto.PostListRes;
 import mogakco.StudyManagement.enums.ErrorCode;
 import mogakco.StudyManagement.service.common.LoggingService;
 import mogakco.StudyManagement.service.post.PostService;
+import mogakco.StudyManagement.util.DateUtil;
 
 @Tag(name = "게시판", description = "게시판 관련 API 분류")
 @SecurityRequirement(name = "bearer-key")
@@ -47,6 +54,29 @@ public class PostController extends CommonController {
             endAPI(request, ErrorCode.OK, lo, result);
         }
         return result;
+    }
+
+    @Operation(summary = "게시글 목록 조회", description = "게시글 검색 및 페이지 별 조회")
+    @GetMapping("/posts")
+    public PostListRes getPostList(
+            HttpServletRequest request, @ModelAttribute @Valid PostListReq postListReq,
+            @PageableDefault(size = 10, page = 0, sort = "createdAt", direction = Sort.Direction.DESC) Pageable pageable) {
+
+        PostListRes result = new PostListRes();
+        try {
+            startAPI(lo, postListReq);
+            result = postService.getPostList(postListReq, lo, pageable);
+            result.setSendDate(DateUtil.getCurrentDateTime());
+            result.setSystemId(systemId);
+        } catch (Exception e) {
+            result = new PostListRes(systemId, ErrorCode.INTERNAL_ERROR.getCode(),
+                    ErrorCode.INTERNAL_ERROR.getMessage(), null, null);
+        } finally {
+            endAPI(request, ErrorCode.OK, lo, result);
+        }
+
+        return result;
+
     }
 
 }

--- a/src/main/java/mogakco/StudyManagement/dto/PostList.java
+++ b/src/main/java/mogakco/StudyManagement/dto/PostList.java
@@ -1,0 +1,35 @@
+package mogakco.StudyManagement.dto;
+
+import lombok.Getter;
+import lombok.Setter;
+import mogakco.StudyManagement.domain.Post;
+
+@Getter
+@Setter
+public class PostList {
+
+    private Integer likes;
+
+    private Integer viewCnt;
+
+    private String title;
+
+    private String member;
+
+    private Integer commentCnt;
+
+    private String createdAt;
+
+    private String updatedAt;
+
+    public PostList(Post post) {
+        this.title = post.getTitle();
+        this.viewCnt = post.getViewCnt();
+        this.member = post.getMember().getName();
+        this.createdAt = post.getCreatedAt();
+        this.updatedAt = post.getUpdatedAt();
+        this.likes = 0;
+        this.commentCnt = 0;
+    }
+
+}

--- a/src/main/java/mogakco/StudyManagement/dto/PostListReq.java
+++ b/src/main/java/mogakco/StudyManagement/dto/PostListReq.java
@@ -14,6 +14,6 @@ public class PostListReq extends DTOReqCommon {
     @NotBlank(message = "한 글자 이상 검색하셔야 합니다")
     private String searchKeyWord;
 
-    private PostSearchType serachType;
+    private PostSearchType searchType;
 
 }

--- a/src/main/java/mogakco/StudyManagement/dto/PostListReq.java
+++ b/src/main/java/mogakco/StudyManagement/dto/PostListReq.java
@@ -1,0 +1,19 @@
+package mogakco.StudyManagement.dto;
+
+import jakarta.validation.constraints.NotBlank;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+import mogakco.StudyManagement.enums.PostSearchType;
+
+@Getter
+@Setter
+@NoArgsConstructor
+public class PostListReq extends DTOReqCommon {
+
+    @NotBlank(message = "한 글자 이상 검색하셔야 합니다")
+    private String searchKeyWord;
+
+    private PostSearchType serachType;
+
+}

--- a/src/main/java/mogakco/StudyManagement/dto/PostListReq.java
+++ b/src/main/java/mogakco/StudyManagement/dto/PostListReq.java
@@ -18,4 +18,10 @@ public class PostListReq extends DTOReqCommon {
 
     private PostSearchType searchType;
 
+    public PostListReq(String sendDate, String systemId, String searchKeyWord, PostSearchType searchType) {
+        super(sendDate, systemId);
+        this.searchKeyWord = searchKeyWord;
+        this.searchType = searchType;
+    }
+
 }

--- a/src/main/java/mogakco/StudyManagement/dto/PostListRes.java
+++ b/src/main/java/mogakco/StudyManagement/dto/PostListRes.java
@@ -1,0 +1,22 @@
+package mogakco.StudyManagement.dto;
+
+import java.util.List;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@Setter
+@NoArgsConstructor
+public class PostListRes extends DTOResCommon {
+
+    private List<PostList> content;
+    private SimplePageable pageable;
+
+    public PostListRes(String systemId, int retCode, String retMsg, List<PostList> content, SimplePageable pageable) {
+        super(systemId, retCode, retMsg);
+        this.content = content;
+        this.pageable = pageable;
+    }
+
+}

--- a/src/main/java/mogakco/StudyManagement/dto/SimplePageable.java
+++ b/src/main/java/mogakco/StudyManagement/dto/SimplePageable.java
@@ -1,0 +1,16 @@
+package mogakco.StudyManagement.dto;
+
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+public class SimplePageable {
+
+    private boolean last;
+    private int page;
+    private int size;
+    private int totalPages;
+    private long totalElements;
+
+}

--- a/src/main/java/mogakco/StudyManagement/enums/PostSearchType.java
+++ b/src/main/java/mogakco/StudyManagement/enums/PostSearchType.java
@@ -1,0 +1,6 @@
+package mogakco.StudyManagement.enums;
+
+public enum PostSearchType {
+    MEMBER,
+    TITLE
+}

--- a/src/main/java/mogakco/StudyManagement/repository/MemberRepository.java
+++ b/src/main/java/mogakco/StudyManagement/repository/MemberRepository.java
@@ -10,5 +10,7 @@ public interface MemberRepository extends JpaRepository<Member, Long> {
 
     Member findById(String id);
 
+    Member findByName(String name);
+
     Boolean existsById(String id);
 }

--- a/src/main/java/mogakco/StudyManagement/repository/MemberRepository.java
+++ b/src/main/java/mogakco/StudyManagement/repository/MemberRepository.java
@@ -1,5 +1,7 @@
 package mogakco.StudyManagement.repository;
 
+import java.util.List;
+
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
@@ -10,7 +12,7 @@ public interface MemberRepository extends JpaRepository<Member, Long> {
 
     Member findById(String id);
 
-    Member findByName(String name);
+    List<Member> findByNameContaining(String name);
 
     Boolean existsById(String id);
 }

--- a/src/main/java/mogakco/StudyManagement/repository/PostRepository.java
+++ b/src/main/java/mogakco/StudyManagement/repository/PostRepository.java
@@ -1,5 +1,7 @@
 package mogakco.StudyManagement.repository;
 
+import java.util.List;
+
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
@@ -11,8 +13,8 @@ import mogakco.StudyManagement.domain.Post;
 @Repository
 public interface PostRepository extends JpaRepository<Post, Long> {
 
-    Page<Post> findByTitle(String title, Pageable pageable);
+    Page<Post> findByTitleContaining(String title, Pageable pageable);
 
-    Page<Post> findByMember(Member member, Pageable pageable);
+    Page<Post> findByMemberIn(List<Member> members, Pageable pageable);
 
 }

--- a/src/main/java/mogakco/StudyManagement/repository/PostRepository.java
+++ b/src/main/java/mogakco/StudyManagement/repository/PostRepository.java
@@ -1,11 +1,18 @@
 package mogakco.StudyManagement.repository;
 
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
+import mogakco.StudyManagement.domain.Member;
 import mogakco.StudyManagement.domain.Post;
 
 @Repository
 public interface PostRepository extends JpaRepository<Post, Long> {
+
+    Page<Post> findByTitle(String title, Pageable pageable);
+
+    Page<Post> findByMember(Member member, Pageable pageable);
 
 }

--- a/src/main/java/mogakco/StudyManagement/service/common/impl/LoggingServiceImpl.java
+++ b/src/main/java/mogakco/StudyManagement/service/common/impl/LoggingServiceImpl.java
@@ -40,8 +40,13 @@ public class LoggingServiceImpl implements LoggingService {
     @Override
     public void setAPIEnd(HttpServletRequest request, ErrorCode errorCode, String systemId) {
         timeAPI = System.currentTimeMillis() - timeAPI;
+
+        StringBuffer requestURL = request.getRequestURL();
+        if (request.getQueryString() != null) {
+            requestURL.append("?").append(request.getQueryString());
+        }
         logger.info("Req: {} {} {}, Res: {}, Duration API: {} ms DB: {} ms", systemId,
-                request.getMethod(), request.getRequestURI(), errorCode, timeAPI, timeDB);
+                request.getMethod(), requestURL.toString(), errorCode, timeAPI, timeDB);
         resetDurations();
     }
 

--- a/src/main/java/mogakco/StudyManagement/service/post/PostService.java
+++ b/src/main/java/mogakco/StudyManagement/service/post/PostService.java
@@ -1,8 +1,14 @@
 package mogakco.StudyManagement.service.post;
 
+import org.springframework.data.domain.Pageable;
+
 import mogakco.StudyManagement.dto.PostCreateReq;
+import mogakco.StudyManagement.dto.PostListReq;
+import mogakco.StudyManagement.dto.PostListRes;
 import mogakco.StudyManagement.service.common.LoggingService;
 
 public interface PostService {
     void createPost(PostCreateReq postCreateReq, LoggingService lo);
+
+    PostListRes getPostList(PostListReq postListReq, LoggingService lo, Pageable pageable);
 }

--- a/src/main/java/mogakco/StudyManagement/service/post/impl/PostServiceImpl.java
+++ b/src/main/java/mogakco/StudyManagement/service/post/impl/PostServiceImpl.java
@@ -52,11 +52,17 @@ public class PostServiceImpl implements PostService {
     @Override
     public PostListRes getPostList(PostListReq postListReq, LoggingService lo, Pageable pageable) {
 
-        Member member = memberRepository.findByName(postListReq.getSearchKeyWord());
+        Page<Post> posts;
+        String searchKeyWord = postListReq.getSearchKeyWord().trim();
 
-        Page<Post> posts = (postListReq.getSerachType() == PostSearchType.TITLE)
-                ? postRepository.findByTitle(postListReq.getSearchKeyWord(), pageable)
-                : postRepository.findByMember(member, pageable);
+        lo.setDBStart();
+        if (postListReq.getSearchType() == PostSearchType.TITLE) {
+            posts = postRepository.findByTitleContaining(searchKeyWord, pageable);
+        } else {
+            List<Member> members = memberRepository.findByNameContaining(searchKeyWord);
+            posts = postRepository.findByMemberIn(members, pageable);
+        }
+        lo.setDBEnd();
 
         List<PostList> postLists = posts.getContent().stream()
                 .map(PostList::new)

--- a/src/main/java/mogakco/StudyManagement/service/post/impl/PostServiceImpl.java
+++ b/src/main/java/mogakco/StudyManagement/service/post/impl/PostServiceImpl.java
@@ -1,15 +1,27 @@
 package mogakco.StudyManagement.service.post.impl;
 
+import java.util.List;
+import java.util.stream.Collectors;
+
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 
 import mogakco.StudyManagement.domain.Member;
 import mogakco.StudyManagement.domain.Post;
 import mogakco.StudyManagement.dto.PostCreateReq;
+import mogakco.StudyManagement.dto.PostList;
+import mogakco.StudyManagement.dto.PostListReq;
+import mogakco.StudyManagement.dto.PostListRes;
+import mogakco.StudyManagement.dto.SimplePageable;
+import mogakco.StudyManagement.enums.ErrorCode;
+import mogakco.StudyManagement.enums.PostSearchType;
 import mogakco.StudyManagement.repository.MemberRepository;
 import mogakco.StudyManagement.repository.PostRepository;
 import mogakco.StudyManagement.service.common.LoggingService;
 import mogakco.StudyManagement.service.post.PostService;
 import mogakco.StudyManagement.util.DateUtil;
+import mogakco.StudyManagement.util.PageUtil;
 import mogakco.StudyManagement.util.SecurityUtil;
 
 @Service
@@ -35,6 +47,27 @@ public class PostServiceImpl implements PostService {
         lo.setDBStart();
         postRepository.save(post);
         lo.setDBEnd();
+    }
+
+    @Override
+    public PostListRes getPostList(PostListReq postListReq, LoggingService lo, Pageable pageable) {
+
+        Member member = memberRepository.findByName(postListReq.getSearchKeyWord());
+
+        Page<Post> posts = (postListReq.getSerachType() == PostSearchType.TITLE)
+                ? postRepository.findByTitle(postListReq.getSearchKeyWord(), pageable)
+                : postRepository.findByMember(member, pageable);
+
+        List<PostList> postLists = posts.getContent().stream()
+                .map(PostList::new)
+                .collect(Collectors.toList());
+
+        SimplePageable simplePageable = PageUtil.createSimplePageable(posts);
+
+        PostListRes result = new PostListRes(null, ErrorCode.OK.getCode(), ErrorCode.OK.getMessage(), postLists,
+                simplePageable);
+
+        return result;
     }
 
 }

--- a/src/main/java/mogakco/StudyManagement/util/PageUtil.java
+++ b/src/main/java/mogakco/StudyManagement/util/PageUtil.java
@@ -1,0 +1,22 @@
+package mogakco.StudyManagement.util;
+
+import org.springframework.data.domain.Page;
+import org.springframework.stereotype.Component;
+
+import mogakco.StudyManagement.dto.SimplePageable;
+
+@Component
+public class PageUtil {
+
+    public static SimplePageable createSimplePageable(Page<?> page) {
+        SimplePageable simplePageable = new SimplePageable();
+        simplePageable.setLast(page.isLast());
+        simplePageable.setPage(page.getNumber());
+        simplePageable.setSize(page.getSize());
+        simplePageable.setTotalPages(page.getTotalPages());
+        simplePageable.setTotalElements(page.getTotalElements());
+
+        return simplePageable;
+    }
+
+}

--- a/src/test/java/mogakco/StudyManagement/controller/PostControllerTest.java
+++ b/src/test/java/mogakco/StudyManagement/controller/PostControllerTest.java
@@ -1,5 +1,7 @@
 package mogakco.StudyManagement.controller;
 
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
 import org.junit.jupiter.api.Test;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
@@ -8,15 +10,20 @@ import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMock
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.security.test.context.support.WithMockUser;
 import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.jdbc.Sql;
 import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.MvcResult;
 import org.springframework.transaction.annotation.Transactional;
 
 import mogakco.StudyManagement.dto.PostCreateReq;
+import mogakco.StudyManagement.dto.PostListReq;
+import mogakco.StudyManagement.enums.PostSearchType;
 import mogakco.StudyManagement.service.common.LoggingService;
 import mogakco.StudyManagement.service.post.PostService;
 import mogakco.StudyManagement.util.DateUtil;
 import mogakco.StudyManagement.util.TestUtil;
 
+import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 
 @ActiveProfiles("test")
@@ -41,6 +48,7 @@ public class PostControllerTest {
     private MockMvc mockMvc;
 
     private static final String CREATE_POST_API_URL = "/api/v1/posts";
+    private static final String GET_POSTS_API_URL = "/api/v1/posts";
 
     @Test
     @WithMockUser(username = "admin", authorities = { "ADMIN" })
@@ -69,6 +77,36 @@ public class PostControllerTest {
                 "  \"content\": \"chatGPT 5.0 도입\"\n"; // Bad Request (Missing closing brace)
 
         TestUtil.performPostRequest(mockMvc, CREATE_POST_API_URL, invalidJson, 400, 400);
+    }
+
+    ///////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+
+    @Test
+    @WithMockUser(username = "admin", authorities = { "ADMIN" })
+    @Sql("/post/PostListSetup.sql")
+    public void getPostListSuccessPage0Size3() throws Exception {
+
+        PostListReq queryParamsObject = new PostListReq(DateUtil.getCurrentDateTime(), "SYS_01", "1",
+                PostSearchType.TITLE);
+        String queryString = objectMapper.writeValueAsString(queryParamsObject);
+
+        MvcResult result = TestUtil.performGetRequest(mockMvc, GET_POSTS_API_URL
+                + "?sendDate=20240112113804899&systemId=STUDY_0001&searchKeyWord=post&searchType=TITLE&page=0&size=3&sort=title,desc",
+                null, 200);
+
+        String content = result.getResponse().getContentAsString();
+
+        ObjectMapper objectMapper = new ObjectMapper();
+        JsonNode rootNode = objectMapper.readTree(content);
+
+        int contentCount = rootNode.path("content").size();
+        assertTrue(contentCount == 3);
+
+        for (JsonNode element : rootNode.path("content")) {
+            String title = element.path("title").asText();
+            assertTrue(title.startsWith("post4"));
+            break;
+        }
     }
 
 }

--- a/src/test/java/mogakco/StudyManagement/controller/PostControllerTest.java
+++ b/src/test/java/mogakco/StudyManagement/controller/PostControllerTest.java
@@ -117,6 +117,32 @@ public class PostControllerTest {
     @Test
     @WithMockUser(username = "admin", authorities = { "ADMIN" })
     @Sql("/post/PostListSetup.sql")
+    public void getPostListSuccessSearchMember() throws Exception {
+
+        UriComponentsBuilder uriBuilder = UriComponentsBuilder.fromUriString(GET_POSTS_API_URL);
+
+        uriBuilder.queryParam("sendDate", DateUtil.getCurrentDateTime())
+                .queryParam("systemId", "SYS_01")
+                .queryParam("searchKeyWord", "PostUser")
+                .queryParam("searchType", PostSearchType.MEMBER)
+                .queryParam("page", 0)
+                .queryParam("size", 4)
+                .queryParam("sort", "title,desc");
+
+        MvcResult result = TestUtil.performGetRequest(mockMvc, uriBuilder.toUriString(), 200);
+
+        String content = result.getResponse().getContentAsString();
+
+        ObjectMapper objectMapper = new ObjectMapper();
+        JsonNode rootNode = objectMapper.readTree(content);
+
+        int contentCount = rootNode.path("content").size();
+        assertTrue(contentCount == 4);
+    }
+
+    @Test
+    @WithMockUser(username = "admin", authorities = { "ADMIN" })
+    @Sql("/post/PostListSetup.sql")
     public void getPostListSuccessPage1Size2() throws Exception {
 
         UriComponentsBuilder uriBuilder = UriComponentsBuilder.fromUriString(GET_POSTS_API_URL);

--- a/src/test/java/mogakco/StudyManagement/util/TestUtil.java
+++ b/src/test/java/mogakco/StudyManagement/util/TestUtil.java
@@ -5,8 +5,14 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 import org.springframework.http.MediaType;
+import org.springframework.stereotype.Component;
 import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.MvcResult;
+import org.springframework.test.web.servlet.ResultActions;
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
+import org.springframework.web.util.UriComponentsBuilder;
 
+@Component
 public class TestUtil {
 
     public static void performPostRequest(MockMvc mockMvc, String url, String requestBodyJson, int expectedStatus,
@@ -17,6 +23,26 @@ public class TestUtil {
                 .content(requestBodyJson))
                 .andExpect(status().is(expectedStatus))
                 .andExpect(expectedRetCode != null ? jsonPath("$.retCode").value(expectedRetCode) : null);
+    }
+
+    public static MvcResult performGetRequest(MockMvc mockMvc, String url, String queryString, int expectedStatus)
+            throws Exception {
+        UriComponentsBuilder uriBuilder = UriComponentsBuilder.fromUriString(url);
+
+        if (queryString != null && !queryString.isEmpty()) {
+            uriBuilder.queryParam("query", queryString);
+        }
+
+        ResultActions resultActions = mockMvc.perform(MockMvcRequestBuilders.get(uriBuilder.toUriString())
+                .contentType(MediaType.APPLICATION_JSON));
+
+        if (expectedStatus == 200) {
+            resultActions.andExpect(status().isOk());
+        } else {
+            resultActions.andExpect(status().is(expectedStatus));
+        }
+
+        return resultActions.andReturn();
     }
 
 }

--- a/src/test/java/mogakco/StudyManagement/util/TestUtil.java
+++ b/src/test/java/mogakco/StudyManagement/util/TestUtil.java
@@ -10,7 +10,6 @@ import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.MvcResult;
 import org.springframework.test.web.servlet.ResultActions;
 import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
-import org.springframework.web.util.UriComponentsBuilder;
 
 @Component
 public class TestUtil {
@@ -25,15 +24,8 @@ public class TestUtil {
                 .andExpect(expectedRetCode != null ? jsonPath("$.retCode").value(expectedRetCode) : null);
     }
 
-    public static MvcResult performGetRequest(MockMvc mockMvc, String url, String queryString, int expectedStatus)
-            throws Exception {
-        UriComponentsBuilder uriBuilder = UriComponentsBuilder.fromUriString(url);
-
-        if (queryString != null && !queryString.isEmpty()) {
-            uriBuilder.queryParam("query", queryString);
-        }
-
-        ResultActions resultActions = mockMvc.perform(MockMvcRequestBuilders.get(uriBuilder.toUriString())
+    public static MvcResult performGetRequest(MockMvc mockMvc, String url, int expectedStatus) throws Exception {
+        ResultActions resultActions = mockMvc.perform(MockMvcRequestBuilders.get(url)
                 .contentType(MediaType.APPLICATION_JSON));
 
         if (expectedStatus == 200) {

--- a/src/test/java/mogakco/StudyManagement/util/TestUtil.java
+++ b/src/test/java/mogakco/StudyManagement/util/TestUtil.java
@@ -5,13 +5,11 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 import org.springframework.http.MediaType;
-import org.springframework.stereotype.Component;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.MvcResult;
 import org.springframework.test.web.servlet.ResultActions;
 import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
 
-@Component
 public class TestUtil {
 
     public static void performPostRequest(MockMvc mockMvc, String url, String requestBodyJson, int expectedStatus,

--- a/src/test/resources/post/PostListSetup.sql
+++ b/src/test/resources/post/PostListSetup.sql
@@ -1,0 +1,22 @@
+INSERT INTO study.`member`
+( contact, created_at , updated_at ,id, name, password, `role`)
+VALUES( '010-1111-1111', '20240112222007395' , '20240112222007395' ,'PostUser', 'PostUser', '$2a$10$LFyW8UyygbwOdyVODxN/lOMVo.Euubxgx9F7c7tX49bqHOgOXE/Z6', 'USER');
+
+
+INSERT INTO study.post (view_cnt, member_id, title, content, created_at, updated_at)
+SELECT
+    0,
+    (SELECT member_id FROM member WHERE id = 'PostUser'),
+    title,
+    content,
+    DATE_FORMAT(NOW(6), '%Y%m%d24%H%i%s%f'),
+    DATE_FORMAT(NOW(6), '%Y%m%d24%H%i%s%f')
+FROM (
+    SELECT 'post1' AS title, 'content1' AS content
+    UNION ALL
+    SELECT 'post2' AS title, 'content2' AS content
+    UNION ALL
+    SELECT 'post3' AS title, 'content3' AS content
+    UNION ALL
+    SELECT 'post4' AS title, 'content4' AS content
+) AS data;


### PR DESCRIPTION
안녕하세요 @dayeon-dayeon 

> 게시글 목록 조회 API를 생성하였습니다
- 작성자(member.name)로 검색
- 제목(title)으로 검색
- 페이지네이션

기능이 구현되어 있습니다

-`PostControllerTest.java` 파일에 테스트를 구현하였고, Swagger로 직접 테스트 하실 경우, 게시글 생성을 먼저 하신 뒤 조회가 가능합니다. 

![ 게시글 조회](https://github.com/ZinnaChoi/Study-Management/assets/142554606/a9066a39-fd90-428a-a4a9-facca2e9b9d1)

위와 같이 pageable 객체에 원하는 input을 입력해 테스트 가능합니다

```json
{
  "page": 0,  // 페이지 인덱스, 0부터 시작
  "size": 3,  // 한 페이지 당 객체 수
  "sort": [
    "title,desc"    // 정렬 기준, 오름차순 OR 내림차순
  ]
}
```

확인 부탁드립니다
감사합니다 😊😊

