### PR TITLE
Task add post patch delete api

### DIFF
--- a/src/main/java/mogakco/StudyManagement/controller/PostController.java
+++ b/src/main/java/mogakco/StudyManagement/controller/PostController.java
@@ -54,7 +54,7 @@ public class PostController extends CommonController {
             result = new DTOResCommon(systemId, ErrorCode.INTERNAL_ERROR.getCode(),
                     ErrorCode.INTERNAL_ERROR.getMessage());
         } finally {
-            endAPI(request, ErrorCode.OK, lo, result);
+            endAPI(request, findErrorCodeByCode(result.getRetCode()), lo, result);
         }
         return result;
     }
@@ -75,7 +75,7 @@ public class PostController extends CommonController {
             result = new PostListRes(systemId, ErrorCode.INTERNAL_ERROR.getCode(),
                     ErrorCode.INTERNAL_ERROR.getMessage(), null, null);
         } finally {
-            endAPI(request, ErrorCode.OK, lo, result);
+            endAPI(request, findErrorCodeByCode(result.getRetCode()), lo, result);
         }
 
         return result;
@@ -103,7 +103,7 @@ public class PostController extends CommonController {
             result = new DTOResCommon(systemId, ErrorCode.INTERNAL_ERROR.getCode(),
                     ErrorCode.INTERNAL_ERROR.getMessage());
         } finally {
-            endAPI(request, ErrorCode.OK, lo, result);
+            endAPI(request, findErrorCodeByCode(result.getRetCode()), lo, result);
         }
         return result;
 
@@ -111,7 +111,22 @@ public class PostController extends CommonController {
 
     @Operation(summary = "게시글 삭제", description = "특정 게시글 삭제. 게시글 작성자만 삭제 가능")
     @DeleteMapping("/posts/{postId}")
-    public void deletePost() {
+    public DTOResCommon deletePost(HttpServletRequest request,
+            @PathVariable(name = "postId", required = true) Long postId) {
+        DTOResCommon result = new DTOResCommon();
+        try {
+            startAPI(lo, null);
+            result = postService.deletePost(postId, lo);
+            result.setSendDate(DateUtil.getCurrentDateTime());
+            result.setSystemId(systemId);
+        } catch (Exception e) {
+            result = new DTOResCommon(systemId, ErrorCode.INTERNAL_ERROR.getCode(),
+                    ErrorCode.INTERNAL_ERROR.getMessage());
+        } finally {
+            endAPI(request, findErrorCodeByCode(result.getRetCode()), lo, result);
+        }
+
+        return result;
     }
 
 }

--- a/src/main/java/mogakco/StudyManagement/controller/PostController.java
+++ b/src/main/java/mogakco/StudyManagement/controller/PostController.java
@@ -3,8 +3,11 @@ package mogakco.StudyManagement.controller;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Sort;
 import org.springframework.data.web.PageableDefault;
+import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.ModelAttribute;
+import org.springframework.web.bind.annotation.PatchMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -16,9 +19,9 @@ import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.validation.Valid;
 import mogakco.StudyManagement.dto.DTOResCommon;
-import mogakco.StudyManagement.dto.PostCreateReq;
 import mogakco.StudyManagement.dto.PostListReq;
 import mogakco.StudyManagement.dto.PostListRes;
+import mogakco.StudyManagement.dto.PostReq;
 import mogakco.StudyManagement.enums.ErrorCode;
 import mogakco.StudyManagement.service.common.LoggingService;
 import mogakco.StudyManagement.service.post.PostService;
@@ -39,7 +42,7 @@ public class PostController extends CommonController {
 
     @Operation(summary = "게시글 등록", description = "새 게시글 추가")
     @PostMapping("/posts")
-    public DTOResCommon createPost(HttpServletRequest request, @RequestBody @Valid PostCreateReq postCreateReq) {
+    public DTOResCommon createPost(HttpServletRequest request, @RequestBody @Valid PostReq postCreateReq) {
 
         DTOResCommon result = new DTOResCommon();
         try {
@@ -77,6 +80,38 @@ public class PostController extends CommonController {
 
         return result;
 
+    }
+
+    // TODO: 구현 필요
+    @Operation(summary = "게시글 상세 정보 조회", description = "특정 게시글의 상세 정보 조회")
+    @GetMapping("/posts/{postId}")
+    public void getPostDetail() {
+    }
+
+    @Operation(summary = "게시글 수정", description = "특정 게시글 수정. 게시글 작성자만 수정 가능")
+    @PatchMapping("/posts/{postId}")
+    public DTOResCommon updatePost(HttpServletRequest request,
+            @PathVariable(name = "postId", required = true) Long postId,
+            @RequestBody @Valid PostReq postUpdateReq) {
+        DTOResCommon result = new DTOResCommon();
+        try {
+            startAPI(lo, postUpdateReq);
+            result = postService.updatePost(postId, postUpdateReq, lo);
+            result.setSendDate(DateUtil.getCurrentDateTime());
+            result.setSystemId(systemId);
+        } catch (Exception e) {
+            result = new DTOResCommon(systemId, ErrorCode.INTERNAL_ERROR.getCode(),
+                    ErrorCode.INTERNAL_ERROR.getMessage());
+        } finally {
+            endAPI(request, ErrorCode.OK, lo, result);
+        }
+        return result;
+
+    }
+
+    @Operation(summary = "게시글 삭제", description = "특정 게시글 삭제. 게시글 작성자만 삭제 가능")
+    @DeleteMapping("/posts/{postId}")
+    public void deletePost() {
     }
 
 }

--- a/src/main/java/mogakco/StudyManagement/domain/Post.java
+++ b/src/main/java/mogakco/StudyManagement/domain/Post.java
@@ -13,6 +13,8 @@ import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import mogakco.StudyManagement.dto.PostReq;
+import java.util.Objects;
 
 @Entity
 @Builder
@@ -44,4 +46,17 @@ public class Post {
 
     @Column(nullable = false)
     private String updatedAt;
+
+    public void updateTitle(String title) {
+        this.title = title;
+    }
+
+    public void updateContent(String content) {
+        this.content = content;
+    }
+
+    public boolean isPostChanged(PostReq postReq) {
+        return (!Objects.equals(title, postReq.getTitle()) || !Objects.equals(content, postReq.getContent()));
+    }
+
 }

--- a/src/main/java/mogakco/StudyManagement/dto/PostReq.java
+++ b/src/main/java/mogakco/StudyManagement/dto/PostReq.java
@@ -10,7 +10,7 @@ import lombok.Setter;
 @Getter
 @Setter
 @NoArgsConstructor
-public class PostCreateReq extends DTOReqCommon {
+public class PostReq extends DTOReqCommon {
 
     @NotBlank(message = "게시글의 제목은 반드시 있어야 합니다")
     @Pattern(regexp = "^.{1,60}$", message = "게시글의 제목은 60자 이하여야 합니다")
@@ -22,7 +22,7 @@ public class PostCreateReq extends DTOReqCommon {
     @Schema(example = "chatGPT 5.0 도입")
     private String content;
 
-    public PostCreateReq(String sendDate, String systemId, String title, String content) {
+    public PostReq(String sendDate, String systemId, String title, String content) {
         super(sendDate, systemId);
         this.title = title;
         this.content = content;

--- a/src/main/java/mogakco/StudyManagement/enums/ErrorCode.java
+++ b/src/main/java/mogakco/StudyManagement/enums/ErrorCode.java
@@ -12,13 +12,13 @@ import lombok.RequiredArgsConstructor;
 
 public enum ErrorCode {
 
-    OK(200, HttpStatus.OK, "Ok"),
-
-    BAD_REQUEST(400, HttpStatus.BAD_REQUEST, "Bad Request:{0}"),
-    NOT_FOUND(404, HttpStatus.NOT_FOUND, "{0} not found"),
-    UNAUTHORIZED(401, HttpStatus.UNAUTHORIZED, "User unauthorized"),
-
-    INTERNAL_ERROR(500, HttpStatus.INTERNAL_SERVER_ERROR, "Internal error");
+    OK(200, HttpStatus.OK, "성공"),
+    DELETED(204, HttpStatus.NO_CONTENT, "{0}이(가) 삭제되었습니다"),
+    UNCHANGED(204, HttpStatus.NO_CONTENT, "{0}은(는) 변경 사항이 없어 업데이트되지 않았습니다."),
+    BAD_REQUEST(400, HttpStatus.BAD_REQUEST, "잘못된 요청: {0}"),
+    UNAUTHORIZED(401, HttpStatus.UNAUTHORIZED, "사용자 권한이 없습니다"),
+    NOT_FOUND(404, HttpStatus.NOT_FOUND, "{0}을(를) 찾을 수 없습니다"),
+    INTERNAL_ERROR(500, HttpStatus.INTERNAL_SERVER_ERROR, "내부 오류 발생");
 
     private final Integer code;
     private final HttpStatus httpStatus;

--- a/src/main/java/mogakco/StudyManagement/repository/PostRepository.java
+++ b/src/main/java/mogakco/StudyManagement/repository/PostRepository.java
@@ -16,8 +16,6 @@ public interface PostRepository extends JpaRepository<Post, Long> {
 
     Optional<Post> findByPostId(Long postId);
 
-    Post findByPostIdAndMember(Long postId, Member member);
-
     Page<Post> findByTitleContaining(String title, Pageable pageable);
 
     Page<Post> findByMemberIn(List<Member> members, Pageable pageable);

--- a/src/main/java/mogakco/StudyManagement/repository/PostRepository.java
+++ b/src/main/java/mogakco/StudyManagement/repository/PostRepository.java
@@ -1,6 +1,7 @@
 package mogakco.StudyManagement.repository;
 
 import java.util.List;
+import java.util.Optional;
 
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
@@ -12,6 +13,10 @@ import mogakco.StudyManagement.domain.Post;
 
 @Repository
 public interface PostRepository extends JpaRepository<Post, Long> {
+
+    Optional<Post> findByPostId(Long postId);
+
+    Post findByPostIdAndMember(Long postId, Member member);
 
     Page<Post> findByTitleContaining(String title, Pageable pageable);
 

--- a/src/main/java/mogakco/StudyManagement/service/post/PostService.java
+++ b/src/main/java/mogakco/StudyManagement/service/post/PostService.java
@@ -2,13 +2,16 @@ package mogakco.StudyManagement.service.post;
 
 import org.springframework.data.domain.Pageable;
 
-import mogakco.StudyManagement.dto.PostCreateReq;
+import mogakco.StudyManagement.dto.PostReq;
+import mogakco.StudyManagement.dto.DTOResCommon;
 import mogakco.StudyManagement.dto.PostListReq;
 import mogakco.StudyManagement.dto.PostListRes;
 import mogakco.StudyManagement.service.common.LoggingService;
 
 public interface PostService {
-    void createPost(PostCreateReq postCreateReq, LoggingService lo);
+    void createPost(PostReq postCreateReq, LoggingService lo);
 
     PostListRes getPostList(PostListReq postListReq, LoggingService lo, Pageable pageable);
+
+    DTOResCommon updatePost(Long postId, PostReq postUpdateReq, LoggingService lo);
 }

--- a/src/main/java/mogakco/StudyManagement/service/post/PostService.java
+++ b/src/main/java/mogakco/StudyManagement/service/post/PostService.java
@@ -14,4 +14,6 @@ public interface PostService {
     PostListRes getPostList(PostListReq postListReq, LoggingService lo, Pageable pageable);
 
     DTOResCommon updatePost(Long postId, PostReq postUpdateReq, LoggingService lo);
+
+    DTOResCommon deletePost(Long postId, LoggingService lo);
 }

--- a/src/main/java/mogakco/StudyManagement/service/post/impl/PostServiceImpl.java
+++ b/src/main/java/mogakco/StudyManagement/service/post/impl/PostServiceImpl.java
@@ -122,13 +122,21 @@ public class PostServiceImpl implements PostService {
         if (!optionalPost.isPresent()) {
             return new DTOResCommon(null, ErrorCode.NOT_FOUND.getCode(),
                     ErrorCode.NOT_FOUND.getMessage("게시글"));
-        } else {
-            lo.setDBStart();
-            postRepository.delete(optionalPost.get());
-            lo.setDBEnd();
-            return new DTOResCommon(null, ErrorCode.DELETED.getCode(),
-                    ErrorCode.DELETED.getMessage("게시글"));
         }
+        Post post = optionalPost.get();
+        lo.setDBStart();
+        Member loginMember = memberRepository.findById(SecurityUtil.getLoginUserId());
+        lo.setDBEnd();
+        if (!post.getMember().equals(loginMember)) {
+            return new DTOResCommon(null, ErrorCode.BAD_REQUEST.getCode(),
+                    ErrorCode.BAD_REQUEST.getMessage("작성하지 않은 게시글은 삭제 수 없습니다."));
+        }
+        lo.setDBStart();
+        postRepository.delete(post);
+        lo.setDBEnd();
+        return new DTOResCommon(null, ErrorCode.DELETED.getCode(),
+                ErrorCode.DELETED.getMessage("게시글"));
+
     }
 
 }

--- a/src/main/java/mogakco/StudyManagement/service/post/impl/PostServiceImpl.java
+++ b/src/main/java/mogakco/StudyManagement/service/post/impl/PostServiceImpl.java
@@ -113,4 +113,22 @@ public class PostServiceImpl implements PostService {
         return new DTOResCommon(null, ErrorCode.OK.getCode(), ErrorCode.OK.getMessage());
     }
 
+    @Override
+    public DTOResCommon deletePost(Long postId, LoggingService lo) {
+        lo.setDBStart();
+        Optional<Post> optionalPost = postRepository.findByPostId(postId);
+        lo.setDBEnd();
+
+        if (!optionalPost.isPresent()) {
+            return new DTOResCommon(null, ErrorCode.NOT_FOUND.getCode(),
+                    ErrorCode.NOT_FOUND.getMessage("게시글"));
+        } else {
+            lo.setDBStart();
+            postRepository.delete(optionalPost.get());
+            lo.setDBEnd();
+            return new DTOResCommon(null, ErrorCode.DELETED.getCode(),
+                    ErrorCode.DELETED.getMessage("게시글"));
+        }
+    }
+
 }

--- a/src/test/java/mogakco/StudyManagement/controller/PostControllerTest.java
+++ b/src/test/java/mogakco/StudyManagement/controller/PostControllerTest.java
@@ -9,11 +9,13 @@ import org.mockito.Mock;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.jdbc.core.JdbcTemplate;
 import org.springframework.security.test.context.support.WithMockUser;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.context.jdbc.Sql;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.MvcResult;
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.util.UriComponentsBuilder;
 
@@ -48,28 +50,33 @@ public class PostControllerTest {
     @Autowired
     private MockMvc mockMvc;
 
-    private static final String CREATE_POST_API_URL = "/api/v1/posts";
-    private static final String GET_POSTS_API_URL = "/api/v1/posts";
+    @Autowired
+    private JdbcTemplate jdbcTemplate;
+
+    private static final String POST_API_URL = "/api/v1/posts";
 
     @Test
-    @WithMockUser(username = "admin", authorities = { "ADMIN" })
+    @Sql("/post/PostListSetup.sql")
+    @WithMockUser(username = "PostUser", authorities = { "USER" })
     public void createPostSuccess() throws Exception {
         String requestBodyJson = objectMapper
                 .writeValueAsString(new PostReq(DateUtil.getCurrentDateTime(), "SYS_01", "2024 2월 개발 뉴스 공유드립니다",
                         "chatGPT 5.0 도입"));
-        TestUtil.performPostRequest(mockMvc, CREATE_POST_API_URL, requestBodyJson, 200, 200);
+        TestUtil.performPostRequest(mockMvc, POST_API_URL, requestBodyJson, 200, 200);
     }
 
     @Test
-    @WithMockUser(username = "admin", authorities = { "ADMIN" })
+    @Sql("/post/PostListSetup.sql")
+    @WithMockUser(username = "PostUser", authorities = { "USER" })
     public void createPostFailEmptyTitle() throws Exception {
         String requestBodyJson = objectMapper
                 .writeValueAsString(new PostReq(DateUtil.getCurrentDateTime(), "SYS_01", null, "chatGPT 5.0 도입"));
-        TestUtil.performPostRequest(mockMvc, CREATE_POST_API_URL, requestBodyJson, 400, 400);
+        TestUtil.performPostRequest(mockMvc, POST_API_URL, requestBodyJson, 400, 400);
     }
 
     @Test
-    @WithMockUser(username = "admin", authorities = { "ADMIN" })
+    @Sql("/post/PostListSetup.sql")
+    @WithMockUser(username = "PostUser", authorities = { "USER" })
     public void createPostFailInvalidJson() throws Exception {
         String invalidJson = "{\n" +
                 "  \"sendDate\": \"20240112132910401\",\n" +
@@ -77,17 +84,17 @@ public class PostControllerTest {
                 "  \"title\": \"2024 2월 개발 뉴스 공유드립니다\",\n" +
                 "  \"content\": \"chatGPT 5.0 도입\"\n"; // Bad Request (Missing closing brace)
 
-        TestUtil.performPostRequest(mockMvc, CREATE_POST_API_URL, invalidJson, 400, 400);
+        TestUtil.performPostRequest(mockMvc, POST_API_URL, invalidJson, 400, 400);
     }
 
     ///////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 
     @Test
-    @WithMockUser(username = "admin", authorities = { "ADMIN" })
     @Sql("/post/PostListSetup.sql")
+    @WithMockUser(username = "PostUser", authorities = { "USER" })
     public void getPostListSuccessPage0Size3() throws Exception {
 
-        UriComponentsBuilder uriBuilder = UriComponentsBuilder.fromUriString(GET_POSTS_API_URL);
+        UriComponentsBuilder uriBuilder = UriComponentsBuilder.fromUriString(POST_API_URL);
 
         uriBuilder.queryParam("sendDate", DateUtil.getCurrentDateTime())
                 .queryParam("systemId", "SYS_01")
@@ -115,11 +122,11 @@ public class PostControllerTest {
     }
 
     @Test
-    @WithMockUser(username = "admin", authorities = { "ADMIN" })
     @Sql("/post/PostListSetup.sql")
+    @WithMockUser(username = "PostUser", authorities = { "USER" })
     public void getPostListSuccessSearchMember() throws Exception {
 
-        UriComponentsBuilder uriBuilder = UriComponentsBuilder.fromUriString(GET_POSTS_API_URL);
+        UriComponentsBuilder uriBuilder = UriComponentsBuilder.fromUriString(POST_API_URL);
 
         uriBuilder.queryParam("sendDate", DateUtil.getCurrentDateTime())
                 .queryParam("systemId", "SYS_01")
@@ -130,7 +137,6 @@ public class PostControllerTest {
                 .queryParam("sort", "title,desc");
 
         MvcResult result = TestUtil.performGetRequest(mockMvc, uriBuilder.toUriString(), 200);
-
         String content = result.getResponse().getContentAsString();
 
         ObjectMapper objectMapper = new ObjectMapper();
@@ -141,11 +147,11 @@ public class PostControllerTest {
     }
 
     @Test
-    @WithMockUser(username = "admin", authorities = { "ADMIN" })
     @Sql("/post/PostListSetup.sql")
+    @WithMockUser(username = "PostUser", authorities = { "USER" })
     public void getPostListSuccessPage1Size2() throws Exception {
 
-        UriComponentsBuilder uriBuilder = UriComponentsBuilder.fromUriString(GET_POSTS_API_URL);
+        UriComponentsBuilder uriBuilder = UriComponentsBuilder.fromUriString(POST_API_URL);
 
         uriBuilder.queryParam("sendDate", DateUtil.getCurrentDateTime())
                 .queryParam("systemId", "SYS_01")
@@ -156,16 +162,12 @@ public class PostControllerTest {
                 .queryParam("sort", "title,desc");
 
         MvcResult result = TestUtil.performGetRequest(mockMvc, uriBuilder.toUriString(), 200);
+        JsonNode responseBody = objectMapper.readTree(result.getResponse().getContentAsString());
 
-        String content = result.getResponse().getContentAsString();
-
-        ObjectMapper objectMapper = new ObjectMapper();
-        JsonNode rootNode = objectMapper.readTree(content);
-
-        int contentCount = rootNode.path("content").size();
+        int contentCount = responseBody.path("content").size();
         assertTrue(contentCount == 2);
 
-        for (JsonNode element : rootNode.path("content")) {
+        for (JsonNode element : responseBody.path("content")) {
             String title = element.path("title").asText();
             assertTrue(title.startsWith("post2"));
             break;
@@ -173,11 +175,11 @@ public class PostControllerTest {
     }
 
     @Test
-    @WithMockUser(username = "admin", authorities = { "ADMIN" })
     @Sql("/post/PostListSetup.sql")
+    @WithMockUser(username = "PostUser", authorities = { "USER" })
     public void getPostListFailInvalidSearchType() throws Exception {
 
-        UriComponentsBuilder uriBuilder = UriComponentsBuilder.fromUriString(GET_POSTS_API_URL);
+        UriComponentsBuilder uriBuilder = UriComponentsBuilder.fromUriString(POST_API_URL);
 
         uriBuilder.queryParam("sendDate", DateUtil.getCurrentDateTime())
                 .queryParam("systemId", "SYS_01")
@@ -192,11 +194,11 @@ public class PostControllerTest {
     }
 
     @Test
-    @WithMockUser(username = "admin", authorities = { "ADMIN" })
     @Sql("/post/PostListSetup.sql")
+    @WithMockUser(username = "PostUser", authorities = { "USER" })
     public void getPostListFailEmptySearchKeyWord() throws Exception {
 
-        UriComponentsBuilder uriBuilder = UriComponentsBuilder.fromUriString(GET_POSTS_API_URL);
+        UriComponentsBuilder uriBuilder = UriComponentsBuilder.fromUriString(POST_API_URL);
 
         uriBuilder.queryParam("sendDate", DateUtil.getCurrentDateTime())
                 .queryParam("systemId", "SYS_01")
@@ -208,6 +210,128 @@ public class PostControllerTest {
 
         MvcResult result = TestUtil.performGetRequest(mockMvc, uriBuilder.toUriString(), 400);
         assertEquals(400, result.getResponse().getStatus());
+    }
+
+    ///////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+
+    @Test
+    @Sql("/post/PostListSetup.sql")
+    @WithMockUser(username = "PostUser", authorities = { "USER" })
+    public void updatePostSuccess() throws Exception {
+
+        String requestBodyJson = objectMapper.writeValueAsString(
+                new PostReq(DateUtil.getCurrentDateTime(), "SYS_01", "Updated Title", "Updated Content"));
+
+        MvcResult result = TestUtil.performPatchRequest(mockMvc,
+                POST_API_URL + "/" + getLatestPostIdByMemberId("PostUser"), requestBodyJson,
+                200);
+
+        JsonNode responseBody = objectMapper.readTree(result.getResponse().getContentAsString());
+
+        for (JsonNode element : responseBody.path("content")) {
+            String title = element.path("title").asText();
+            assertTrue(title.startsWith("Updated Content"));
+            break;
+        }
+    }
+
+    @Test
+    @Sql("/post/PostListSetup.sql")
+    @WithMockUser(username = "PostUser", authorities = { "USER" })
+    public void updatePostFailPostNotFound() throws Exception {
+        String requestBodyJson = objectMapper.writeValueAsString(
+                new PostReq(DateUtil.getCurrentDateTime(), "SYS_01", "Updated Title", "Updated Content"));
+
+        // Not Exist postId -1
+        MvcResult result = TestUtil.performPatchRequest(mockMvc,
+                POST_API_URL + "/" + -1, requestBodyJson,
+                200);
+
+        JsonNode responseBody = objectMapper.readTree(result.getResponse().getContentAsString());
+
+        for (JsonNode element : responseBody.path("retCode")) {
+            String retCode = element.path("retCode").asText();
+            assertEquals(404, retCode);
+            break;
+        }
+    }
+
+    @Test
+    @Sql("/post/PostListSetup.sql")
+    @WithMockUser(username = "PostUser2", authorities = { "USER" }) // Differnet Member
+    public void updatePostFailPostDiffMember() throws Exception {
+
+        String requestBodyJson = objectMapper.writeValueAsString(
+                new PostReq(DateUtil.getCurrentDateTime(), "SYS_01", "Updated Title", "Updated Content"));
+
+        MvcResult result = TestUtil.performPatchRequest(mockMvc,
+                POST_API_URL + "/" + getLatestPostIdByMemberId("PostUser"), requestBodyJson,
+                200);
+
+        JsonNode responseBody = objectMapper.readTree(result.getResponse().getContentAsString());
+
+        for (JsonNode element : responseBody.path("retCode")) {
+            String retCode = element.path("retCode").asText();
+            assertEquals(400, retCode);
+            break;
+        }
+    }
+
+    ///////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+
+    @Test
+    @Sql("/post/PostListSetup.sql")
+    @WithMockUser(username = "PostUser", authorities = { "USER" })
+    public void deletePostSuccess() throws Exception {
+
+        MvcResult result = TestUtil.performDeleteRequest(mockMvc,
+                POST_API_URL + "/" + getLatestPostIdByMemberId("PostUser"), 200);
+
+        JsonNode responseBody = objectMapper.readTree(result.getResponse().getContentAsString());
+        for (JsonNode element : responseBody.path("retCode")) {
+            String retCode = element.path("retCode").asText();
+            assertEquals(204, retCode);
+            break;
+        }
+    }
+
+    @Test
+    @Sql("/post/PostListSetup.sql")
+    @WithMockUser(username = "PostUser", authorities = { "USER" })
+    public void deletePostFailNotFound() throws Exception {
+        MvcResult result = TestUtil.performDeleteRequest(mockMvc,
+                POST_API_URL + "/" + -1, 200); // Not Exist PostId
+
+        JsonNode responseBody = objectMapper.readTree(result.getResponse().getContentAsString());
+        for (JsonNode element : responseBody.path("retCode")) {
+            String retCode = element.path("retCode").asText();
+            assertEquals(404, retCode);
+            break;
+        }
+    }
+
+    @Test
+    @Sql("/post/PostListSetup.sql")
+    @WithMockUser(username = "PostUser2", authorities = { "USER" }) // Differnet Member
+    public void deletePostFailDiffMember() throws Exception {
+        MvcResult result = TestUtil.performDeleteRequest(mockMvc,
+                POST_API_URL + "/" + getLatestPostIdByMemberId("PostUser"), 200);
+
+        JsonNode responseBody = objectMapper.readTree(result.getResponse().getContentAsString());
+        for (JsonNode element : responseBody.path("retCode")) {
+            String retCode = element.path("retCode").asText();
+            assertEquals(400, retCode);
+            break;
+        }
+    }
+
+    ///////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+
+    public Long getLatestPostIdByMemberId(String memberId) {
+        return jdbcTemplate.queryForObject(
+                "SELECT post_id FROM post WHERE member_id = (SELECT member_id FROM member WHERE id = ?) ORDER BY created_at DESC LIMIT 1",
+                Long.class,
+                memberId);
     }
 
 }

--- a/src/test/java/mogakco/StudyManagement/controller/PostControllerTest.java
+++ b/src/test/java/mogakco/StudyManagement/controller/PostControllerTest.java
@@ -17,7 +17,7 @@ import org.springframework.test.web.servlet.MvcResult;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.util.UriComponentsBuilder;
 
-import mogakco.StudyManagement.dto.PostCreateReq;
+import mogakco.StudyManagement.dto.PostReq;
 import mogakco.StudyManagement.enums.PostSearchType;
 import mogakco.StudyManagement.service.common.LoggingService;
 import mogakco.StudyManagement.service.post.PostService;
@@ -55,7 +55,7 @@ public class PostControllerTest {
     @WithMockUser(username = "admin", authorities = { "ADMIN" })
     public void createPostSuccess() throws Exception {
         String requestBodyJson = objectMapper
-                .writeValueAsString(new PostCreateReq(DateUtil.getCurrentDateTime(), "SYS_01", "2024 2월 개발 뉴스 공유드립니다",
+                .writeValueAsString(new PostReq(DateUtil.getCurrentDateTime(), "SYS_01", "2024 2월 개발 뉴스 공유드립니다",
                         "chatGPT 5.0 도입"));
         TestUtil.performPostRequest(mockMvc, CREATE_POST_API_URL, requestBodyJson, 200, 200);
     }
@@ -64,7 +64,7 @@ public class PostControllerTest {
     @WithMockUser(username = "admin", authorities = { "ADMIN" })
     public void createPostFailEmptyTitle() throws Exception {
         String requestBodyJson = objectMapper
-                .writeValueAsString(new PostCreateReq(DateUtil.getCurrentDateTime(), "SYS_01", null, "chatGPT 5.0 도입"));
+                .writeValueAsString(new PostReq(DateUtil.getCurrentDateTime(), "SYS_01", null, "chatGPT 5.0 도입"));
         TestUtil.performPostRequest(mockMvc, CREATE_POST_API_URL, requestBodyJson, 400, 400);
     }
 

--- a/src/test/java/mogakco/StudyManagement/controller/PostControllerTest.java
+++ b/src/test/java/mogakco/StudyManagement/controller/PostControllerTest.java
@@ -1,12 +1,13 @@
 package mogakco.StudyManagement.controller;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
+import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.jdbc.core.JdbcTemplate;
@@ -32,6 +33,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 @AutoConfigureMockMvc
 @SpringBootTest
 @Transactional
+@DisplayName("게시글 테스트")
 public class PostControllerTest {
 
     @Mock
@@ -52,14 +54,18 @@ public class PostControllerTest {
     @Autowired
     private JdbcTemplate jdbcTemplate;
 
+    @Value("${study.systemId}")
+    private String systemId;
+
     private static final String POST_API_URL = "/api/v1/posts";
 
     @Test
     @Sql("/post/PostListSetup.sql")
     @WithMockUser(username = "PostUser", authorities = { "USER" })
+    @DisplayName("게시글 등록 성공")
     public void createPostSuccess() throws Exception {
         String requestBodyJson = objectMapper
-                .writeValueAsString(new PostReq(DateUtil.getCurrentDateTime(), "SYS_01", "2024 2월 개발 뉴스 공유드립니다",
+                .writeValueAsString(new PostReq(DateUtil.getCurrentDateTime(), systemId, "2024 2월 개발 뉴스 공유드립니다",
                         "chatGPT 5.0 도입"));
         TestUtil.performRequest(mockMvc, POST_API_URL, requestBodyJson, "POST", 200, 200);
     }
@@ -67,19 +73,21 @@ public class PostControllerTest {
     @Test
     @Sql("/post/PostListSetup.sql")
     @WithMockUser(username = "PostUser", authorities = { "USER" })
+    @DisplayName("게시글 등록 실패 - 빈 제목")
     public void createPostFailEmptyTitle() throws Exception {
         String requestBodyJson = objectMapper
-                .writeValueAsString(new PostReq(DateUtil.getCurrentDateTime(), "SYS_01", null, "chatGPT 5.0 도입"));
+                .writeValueAsString(new PostReq(DateUtil.getCurrentDateTime(), systemId, null, "chatGPT 5.0 도입"));
         TestUtil.performRequest(mockMvc, POST_API_URL, requestBodyJson, "POST", 400, 400);
     }
 
     @Test
     @Sql("/post/PostListSetup.sql")
     @WithMockUser(username = "PostUser", authorities = { "USER" })
+    @DisplayName("게시글 등록 실패 - 잘못된 요청 JSON 형식")
     public void createPostFailInvalidJson() throws Exception {
         String invalidJson = "{\n" +
                 "  \"sendDate\": \"20240112132910401\",\n" +
-                "  \"systemId\": \"SYS_01\",\n" +
+                "  \"systemId\": \"ABC\",\n" +
                 "  \"title\": \"2024 2월 개발 뉴스 공유드립니다\",\n" +
                 "  \"content\": \"chatGPT 5.0 도입\"\n"; // Bad Request (Missing closing brace)
 
@@ -91,12 +99,13 @@ public class PostControllerTest {
     @Test
     @Sql("/post/PostListSetup.sql")
     @WithMockUser(username = "PostUser", authorities = { "USER" })
+    @DisplayName("게시글 목록 조회 성공 - Page 0 Size 3")
     public void getPostListSuccessPage0Size3() throws Exception {
 
         UriComponentsBuilder uriBuilder = UriComponentsBuilder.fromUriString(POST_API_URL);
 
         uriBuilder.queryParam("sendDate", DateUtil.getCurrentDateTime())
-                .queryParam("systemId", "SYS_01")
+                .queryParam("systemId", systemId)
                 .queryParam("searchKeyWord", "post")
                 .queryParam("searchType", PostSearchType.TITLE)
                 .queryParam("page", 0)
@@ -104,16 +113,12 @@ public class PostControllerTest {
                 .queryParam("sort", "title,desc");
 
         MvcResult result = TestUtil.performRequest(mockMvc, uriBuilder.toUriString(), null, "GET", 200, 200);
+        JsonNode responseBody = objectMapper.readTree(result.getResponse().getContentAsString());
 
-        String content = result.getResponse().getContentAsString();
-
-        ObjectMapper objectMapper = new ObjectMapper();
-        JsonNode rootNode = objectMapper.readTree(content);
-
-        int contentCount = rootNode.path("content").size();
+        int contentCount = responseBody.path("content").size();
         assertTrue(contentCount == 3);
 
-        for (JsonNode element : rootNode.path("content")) {
+        for (JsonNode element : responseBody.path("content")) {
             String title = element.path("title").asText();
             assertTrue(title.startsWith("post4"));
             break;
@@ -123,12 +128,13 @@ public class PostControllerTest {
     @Test
     @Sql("/post/PostListSetup.sql")
     @WithMockUser(username = "PostUser", authorities = { "USER" })
+    @DisplayName("게시글 목록 조회 성공 - 작성자 이름으로 조회")
     public void getPostListSuccessSearchMember() throws Exception {
 
         UriComponentsBuilder uriBuilder = UriComponentsBuilder.fromUriString(POST_API_URL);
 
         uriBuilder.queryParam("sendDate", DateUtil.getCurrentDateTime())
-                .queryParam("systemId", "SYS_01")
+                .queryParam("systemId", systemId)
                 .queryParam("searchKeyWord", "PostUser")
                 .queryParam("searchType", PostSearchType.MEMBER)
                 .queryParam("page", 0)
@@ -136,25 +142,22 @@ public class PostControllerTest {
                 .queryParam("sort", "title,desc");
 
         MvcResult result = TestUtil.performRequest(mockMvc, uriBuilder.toUriString(), null, "GET", 200, 200);
+        JsonNode responseBody = objectMapper.readTree(result.getResponse().getContentAsString());
 
-        String content = result.getResponse().getContentAsString();
-
-        ObjectMapper objectMapper = new ObjectMapper();
-        JsonNode rootNode = objectMapper.readTree(content);
-
-        int contentCount = rootNode.path("content").size();
+        int contentCount = responseBody.path("content").size();
         assertTrue(contentCount == 4);
     }
 
     @Test
     @Sql("/post/PostListSetup.sql")
     @WithMockUser(username = "PostUser", authorities = { "USER" })
+    @DisplayName("게시글 목록 조회 성공 - Page 1 Size 2")
     public void getPostListSuccessPage1Size2() throws Exception {
 
         UriComponentsBuilder uriBuilder = UriComponentsBuilder.fromUriString(POST_API_URL);
 
         uriBuilder.queryParam("sendDate", DateUtil.getCurrentDateTime())
-                .queryParam("systemId", "SYS_01")
+                .queryParam("systemId", systemId)
                 .queryParam("searchKeyWord", "post")
                 .queryParam("searchType", PostSearchType.TITLE)
                 .queryParam("page", 1)
@@ -177,12 +180,13 @@ public class PostControllerTest {
     @Test
     @Sql("/post/PostListSetup.sql")
     @WithMockUser(username = "PostUser", authorities = { "USER" })
+    @DisplayName("게시글 목록 조회 실패 - 잘못된 검색 타입")
     public void getPostListFailInvalidSearchType() throws Exception {
 
         UriComponentsBuilder uriBuilder = UriComponentsBuilder.fromUriString(POST_API_URL);
 
         uriBuilder.queryParam("sendDate", DateUtil.getCurrentDateTime())
-                .queryParam("systemId", "SYS_01")
+                .queryParam("systemId", systemId)
                 .queryParam("searchKeyWord", "post")
                 .queryParam("searchType", "INVALID_TYPE") // Invalid SearchType
                 .queryParam("page", 0)
@@ -195,12 +199,13 @@ public class PostControllerTest {
     @Test
     @Sql("/post/PostListSetup.sql")
     @WithMockUser(username = "PostUser", authorities = { "USER" })
+    @DisplayName("게시글 목록 조회 실패 - 빈 검색어")
     public void getPostListFailEmptySearchKeyWord() throws Exception {
 
         UriComponentsBuilder uriBuilder = UriComponentsBuilder.fromUriString(POST_API_URL);
 
         uriBuilder.queryParam("sendDate", DateUtil.getCurrentDateTime())
-                .queryParam("systemId", "SYS_01")
+                .queryParam("systemId", systemId)
                 .queryParam("searchKeyWord", "")
                 .queryParam("searchType", PostSearchType.TITLE)
                 .queryParam("page", 0)
@@ -215,10 +220,11 @@ public class PostControllerTest {
     @Test
     @Sql("/post/PostListSetup.sql")
     @WithMockUser(username = "PostUser", authorities = { "USER" })
+    @DisplayName("게시글 수정 성공")
     public void updatePostSuccess() throws Exception {
 
         String requestBodyJson = objectMapper.writeValueAsString(
-                new PostReq(DateUtil.getCurrentDateTime(), "SYS_01", "Updated Title", "Updated Content"));
+                new PostReq(DateUtil.getCurrentDateTime(), systemId, "Updated Title", "Updated Content"));
 
         MvcResult result = TestUtil.performRequest(mockMvc,
                 POST_API_URL + "/" + getLatestPostIdByMemberId("PostUser"), requestBodyJson, "PATCH", 200, 200);
@@ -234,9 +240,10 @@ public class PostControllerTest {
     @Test
     @Sql("/post/PostListSetup.sql")
     @WithMockUser(username = "PostUser", authorities = { "USER" })
+    @DisplayName("게시글 수정 실패 - 잘못된 게시글 번호")
     public void updatePostFailPostNotFound() throws Exception {
         String requestBodyJson = objectMapper.writeValueAsString(
-                new PostReq(DateUtil.getCurrentDateTime(), "SYS_01", "Updated Title", "Updated Content"));
+                new PostReq(DateUtil.getCurrentDateTime(), systemId, "Updated Title", "Updated Content"));
 
         // Not Exist postId -1
         TestUtil.performRequest(mockMvc,
@@ -245,11 +252,12 @@ public class PostControllerTest {
 
     @Test
     @Sql("/post/PostListSetup.sql")
-    @WithMockUser(username = "PostUser2", authorities = { "USER" }) // Differnet Member
+    @WithMockUser(username = "PostUser2", authorities = { "USER" })
+    @DisplayName("게시글 수정 실패 - 잘못된 사용자")
     public void updatePostFailPostDiffMember() throws Exception {
 
         String requestBodyJson = objectMapper.writeValueAsString(
-                new PostReq(DateUtil.getCurrentDateTime(), "SYS_01", "Updated Title", "Updated Content"));
+                new PostReq(DateUtil.getCurrentDateTime(), systemId, "Updated Title", "Updated Content"));
 
         TestUtil.performRequest(mockMvc,
                 POST_API_URL + "/" + getLatestPostIdByMemberId("PostUser"), requestBodyJson, "PATCH", 200, 400);
@@ -260,6 +268,7 @@ public class PostControllerTest {
     @Test
     @Sql("/post/PostListSetup.sql")
     @WithMockUser(username = "PostUser", authorities = { "USER" })
+    @DisplayName("게시글 삭제 성공")
     public void deletePostSuccess() throws Exception {
 
         TestUtil.performRequest(mockMvc,
@@ -269,6 +278,7 @@ public class PostControllerTest {
     @Test
     @Sql("/post/PostListSetup.sql")
     @WithMockUser(username = "PostUser", authorities = { "USER" })
+    @DisplayName("게시글 삭제 실패 - 잘못된 게시글 번호")
     public void deletePostFailNotFound() throws Exception {
         TestUtil.performRequest(mockMvc,
                 POST_API_URL + "/" + -1, null, "DELETE", 200, 404); // Not Exist PostId
@@ -276,7 +286,8 @@ public class PostControllerTest {
 
     @Test
     @Sql("/post/PostListSetup.sql")
-    @WithMockUser(username = "PostUser2", authorities = { "USER" }) // Differnet Member
+    @WithMockUser(username = "PostUser2", authorities = { "USER" })
+    @DisplayName("게시글 삭제 실패 - 잘못된 사용자")
     public void deletePostFailDiffMember() throws Exception {
         TestUtil.performRequest(mockMvc,
                 POST_API_URL + "/" + getLatestPostIdByMemberId("PostUser"), null, "DELETE", 200, 400);

--- a/src/test/java/mogakco/StudyManagement/util/TestUtil.java
+++ b/src/test/java/mogakco/StudyManagement/util/TestUtil.java
@@ -35,4 +35,32 @@ public class TestUtil {
         return resultActions.andReturn();
     }
 
+    public static MvcResult performPatchRequest(MockMvc mockMvc, String url, String requestBodyJson, int expectedStatus)
+            throws Exception {
+        ResultActions resultActions = mockMvc.perform(MockMvcRequestBuilders.patch(url)
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(requestBodyJson));
+
+        if (expectedStatus == 200) {
+            resultActions.andExpect(status().isOk());
+        } else {
+            resultActions.andExpect(status().is(expectedStatus));
+        }
+
+        return resultActions.andReturn();
+    }
+
+    public static MvcResult performDeleteRequest(MockMvc mockMvc, String url, int expectedStatus) throws Exception {
+        ResultActions resultActions = mockMvc.perform(MockMvcRequestBuilders.delete(url)
+                .contentType(MediaType.APPLICATION_JSON));
+
+        if (expectedStatus == 200) {
+            resultActions.andExpect(status().isOk());
+        } else {
+            resultActions.andExpect(status().is(expectedStatus));
+        }
+
+        return resultActions.andReturn();
+    }
+
 }

--- a/src/test/java/mogakco/StudyManagement/util/TestUtil.java
+++ b/src/test/java/mogakco/StudyManagement/util/TestUtil.java
@@ -7,10 +7,50 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 import org.springframework.http.MediaType;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.MvcResult;
+import org.springframework.test.web.servlet.RequestBuilder;
 import org.springframework.test.web.servlet.ResultActions;
 import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
 
 public class TestUtil {
+
+    public static MvcResult performRequest(MockMvc mockMvc, String url, String requestBodyJson, String method,
+            int expectedStatus, Integer expectedRetCode) throws Exception {
+        ResultActions resultActions = null;
+        RequestBuilder requestBuilder = null;
+
+        switch (method) {
+            case "GET":
+                requestBuilder = MockMvcRequestBuilders.get(url).contentType(MediaType.APPLICATION_JSON);
+                break;
+            case "POST":
+                requestBuilder = MockMvcRequestBuilders.post(url).contentType(MediaType.APPLICATION_JSON)
+                        .content(requestBodyJson);
+                break;
+            case "PATCH":
+                requestBuilder = MockMvcRequestBuilders.patch(url).contentType(MediaType.APPLICATION_JSON)
+                        .content(requestBodyJson);
+                break;
+            case "DELETE":
+                requestBuilder = MockMvcRequestBuilders.delete(url).contentType(MediaType.APPLICATION_JSON);
+                break;
+            default:
+                throw new IllegalArgumentException("Invalid HTTP method: " + method);
+        }
+
+        resultActions = mockMvc.perform(requestBuilder);
+
+        if (expectedStatus == 200) {
+            resultActions.andExpect(status().isOk());
+        } else {
+            resultActions.andExpect(status().is(expectedStatus));
+        }
+
+        if (expectedRetCode != null) {
+            resultActions.andExpect(jsonPath("$.retCode").value(expectedRetCode));
+        }
+
+        return resultActions.andReturn();
+    }
 
     public static void performPostRequest(MockMvc mockMvc, String url, String requestBodyJson, int expectedStatus,
             Integer expectedRetCode)
@@ -24,34 +64,6 @@ public class TestUtil {
 
     public static MvcResult performGetRequest(MockMvc mockMvc, String url, int expectedStatus) throws Exception {
         ResultActions resultActions = mockMvc.perform(MockMvcRequestBuilders.get(url)
-                .contentType(MediaType.APPLICATION_JSON));
-
-        if (expectedStatus == 200) {
-            resultActions.andExpect(status().isOk());
-        } else {
-            resultActions.andExpect(status().is(expectedStatus));
-        }
-
-        return resultActions.andReturn();
-    }
-
-    public static MvcResult performPatchRequest(MockMvc mockMvc, String url, String requestBodyJson, int expectedStatus)
-            throws Exception {
-        ResultActions resultActions = mockMvc.perform(MockMvcRequestBuilders.patch(url)
-                .contentType(MediaType.APPLICATION_JSON)
-                .content(requestBodyJson));
-
-        if (expectedStatus == 200) {
-            resultActions.andExpect(status().isOk());
-        } else {
-            resultActions.andExpect(status().is(expectedStatus));
-        }
-
-        return resultActions.andReturn();
-    }
-
-    public static MvcResult performDeleteRequest(MockMvc mockMvc, String url, int expectedStatus) throws Exception {
-        ResultActions resultActions = mockMvc.perform(MockMvcRequestBuilders.delete(url)
                 .contentType(MediaType.APPLICATION_JSON));
 
         if (expectedStatus == 200) {

--- a/src/test/resources/post/PostListSetup.sql
+++ b/src/test/resources/post/PostListSetup.sql
@@ -1,6 +1,8 @@
 INSERT INTO study.`member`
-( contact, created_at , updated_at ,id, name, password, `role`)
-VALUES( '010-1111-1111', '20240112222007395' , '20240112222007395' ,'PostUser', 'PostUser', '$2a$10$LFyW8UyygbwOdyVODxN/lOMVo.Euubxgx9F7c7tX49bqHOgOXE/Z6', 'USER');
+(contact, created_at, updated_at, id, name, password, `role`)
+VALUES
+('010-1111-1111', '20240112222007395', '20240112222007395', 'PostUser', 'PostUser', '$2a$10$LFyW8UyygbwOdyVODxN/lOMVo.Euubxgx9F7c7tX49bqHOgOXE/Z6', 'USER'),
+('010-1111-1111', '20240112222007395', '20240112222007395', 'PostUser2', 'PostUser2', '$2a$10$LFyW8UyygbwOdyVODxN/lOMVo.Euubxgx9F7c7tX49bqHOgOXE/Z6', 'USER');
 
 
 INSERT INTO study.post (view_cnt, member_id, title, content, created_at, updated_at)


### PR DESCRIPTION
안녕하세요 @dayeon-dayeon~~

### 변경사항 
- Post(게시글) 수정, 삭제 API를 생성하였습니다!
  - 두 API 모두 로그인한 사용자가 해당 게시물을 생성했을 때만 수정/삭제가 가능하게 처리해두었습니다
- ErrorCode의 메세지를 한국어로 통일했습니다
- testUtil의 `performRequest` 리팩토링도 진행하였습니다 
  - 메서드(post, get,...)와 상관 없이, 동일하게 performRequest()를 호출해서 test를 진행할 수 있습니다

확인 부탁드립니다 
감사합니다!
 