### PR TITLE
Mypage member info get api

### DIFF
--- a/src/main/java/mogakco/StudyManagement/controller/MemberController.java
+++ b/src/main/java/mogakco/StudyManagement/controller/MemberController.java
@@ -8,6 +8,7 @@ import org.springframework.web.bind.annotation.RestController;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.servlet.http.HttpServletRequest;
+import jakarta.validation.Valid;
 import mogakco.StudyManagement.dto.DTOResCommon;
 import mogakco.StudyManagement.dto.MemberIdDuplReq;
 import mogakco.StudyManagement.dto.MemberIdDuplRes;
@@ -57,7 +58,7 @@ public class MemberController extends CommonController {
 
     @Operation(summary = "회원가입", description = "회원가입을 통해 사용자 정보 등록")
     @PostMapping("/join")
-    public DTOResCommon doJoin(HttpServletRequest request, @RequestBody MemberJoinReq joinInfo) {
+    public DTOResCommon doJoin(HttpServletRequest request, @Valid @RequestBody MemberJoinReq joinInfo) {
         DTOResCommon result = new DTOResCommon();
 
         try {

--- a/src/main/java/mogakco/StudyManagement/controller/MemberController.java
+++ b/src/main/java/mogakco/StudyManagement/controller/MemberController.java
@@ -1,17 +1,22 @@
 package mogakco.StudyManagement.controller;
 
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.ModelAttribute;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
 import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.validation.Valid;
+import mogakco.StudyManagement.dto.DTOReqCommon;
 import mogakco.StudyManagement.dto.DTOResCommon;
 import mogakco.StudyManagement.dto.MemberIdDuplReq;
 import mogakco.StudyManagement.dto.MemberIdDuplRes;
+import mogakco.StudyManagement.dto.MemberInfoRes;
 import mogakco.StudyManagement.dto.MemberJoinReq;
 import mogakco.StudyManagement.dto.MemberLoginReq;
 import mogakco.StudyManagement.dto.MemberLoginRes;
@@ -97,6 +102,31 @@ public class MemberController extends CommonController {
         } catch (Exception e) {
             result = new MemberIdDuplRes(systemId, ErrorCode.INTERNAL_ERROR.getCode(),
                     ErrorCode.INTERNAL_ERROR.getMessage());
+        } finally {
+            endAPI(request, findErrorCodeByCode(result.getRetCode()), lo, result);
+        }
+        return result;
+
+    }
+
+    @Operation(summary = "MyPage 회원 정보 조회", description = "로그인 된 회원 정보 조회")
+    @SecurityRequirement(name = "bearer-key")
+    @GetMapping("/member")
+    public MemberInfoRes getMemberInfo(HttpServletRequest request, @ModelAttribute DTOReqCommon info) {
+        MemberInfoRes result = new MemberInfoRes();
+
+        try {
+            startAPI(lo, info);
+            if (info.getSendDate() == null) {
+                result = new MemberInfoRes(systemId, ErrorCode.NOT_FOUND.getCode(),
+                        ErrorCode.NOT_FOUND.getMessage("sendDate"), null, null, null, null, null, null, null);
+            } else {
+                result = memberService.getMemberInfo(lo);
+                result.setSendDate(DateUtil.getCurrentDateTime());
+            }
+        } catch (Exception e) {
+            result = new MemberInfoRes(systemId, ErrorCode.INTERNAL_ERROR.getCode(),
+                    ErrorCode.INTERNAL_ERROR.getMessage(), null, null, null, null, null, null, null);
         } finally {
             endAPI(request, findErrorCodeByCode(result.getRetCode()), lo, result);
         }

--- a/src/main/java/mogakco/StudyManagement/dto/MemberIdDuplReq.java
+++ b/src/main/java/mogakco/StudyManagement/dto/MemberIdDuplReq.java
@@ -1,11 +1,15 @@
 package mogakco.StudyManagement.dto;
 
 import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.AllArgsConstructor;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 import lombok.Setter;
 
 @Getter
 @Setter
+@AllArgsConstructor
+@NoArgsConstructor
 public class MemberIdDuplReq extends DTOReqCommon {
     @Schema(example = "admin")
     private String id;

--- a/src/main/java/mogakco/StudyManagement/dto/MemberInfoRes.java
+++ b/src/main/java/mogakco/StudyManagement/dto/MemberInfoRes.java
@@ -1,0 +1,50 @@
+package mogakco.StudyManagement.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+import java.util.List;
+import mogakco.StudyManagement.enums.MemberRole;
+
+@Getter
+@Setter
+@AllArgsConstructor
+@NoArgsConstructor
+public class MemberInfoRes extends DTOResCommon {
+
+    @Schema(example = "user1")
+    private String id;
+
+    @Schema(example = "HongGilDong")
+    private String name;
+
+    @Schema(example = "01011112222")
+    private String contact;
+
+    @Schema(example = "USER")
+    private MemberRole role;
+
+    @Schema(example = "모각코 스터디")
+    private String studyName;
+
+    @Schema(example = "AM1")
+    private List<String> eventName;
+
+    @Schema(example = "1530")
+    private String wakeupTime;
+
+    public MemberInfoRes(String systemId, int retCode, String retMsg, String id, String name, String contact,
+            MemberRole role, String studyName, List<String> eventName, String wakeupTime) {
+        super(systemId, retCode, retMsg);
+        this.id = id;
+        this.name = name;
+        this.contact = contact;
+        this.role = role;
+        this.studyName = studyName;
+        this.eventName = eventName;
+        this.wakeupTime = wakeupTime;
+    }
+
+}

--- a/src/main/java/mogakco/StudyManagement/dto/MemberJoinReq.java
+++ b/src/main/java/mogakco/StudyManagement/dto/MemberJoinReq.java
@@ -14,7 +14,7 @@ public class MemberJoinReq extends DTOReqCommon {
     @NotBlank(message = "아이디는 필수 입력 항목입니다.")
     private String id;
 
-    @Schema(example = "pwd")
+    @Schema(example = "password123!")
     @NotBlank(message = "비밀번호는 필수 입력 항목입니다.")
     @Pattern(regexp = "(?=.*[0-9])(?=.*[a-zA-Z])(?=.*\\W)(?=\\S+$).{8,16}", message = "비밀번호는 8~16자 영문 대 소문자, 숫자, 특수문자를 사용하세요.")
     private String password;

--- a/src/main/java/mogakco/StudyManagement/dto/MemberJoinReq.java
+++ b/src/main/java/mogakco/StudyManagement/dto/MemberJoinReq.java
@@ -1,6 +1,8 @@
 package mogakco.StudyManagement.dto;
 
 import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Pattern;
 import lombok.Getter;
 import lombok.Setter;
 
@@ -9,9 +11,12 @@ import lombok.Setter;
 public class MemberJoinReq extends DTOReqCommon {
 
     @Schema(example = "user1")
+    @NotBlank(message = "아이디는 필수 입력 항목입니다.")
     private String id;
 
     @Schema(example = "pwd")
+    @NotBlank(message = "비밀번호는 필수 입력 항목입니다.")
+    @Pattern(regexp = "(?=.*[0-9])(?=.*[a-zA-Z])(?=.*\\W)(?=\\S+$).{8,16}", message = "비밀번호는 8~16자 영문 대 소문자, 숫자, 특수문자를 사용하세요.")
     private String password;
 
     @Schema(example = "HongGilDong")

--- a/src/main/java/mogakco/StudyManagement/dto/MemberJoinReq.java
+++ b/src/main/java/mogakco/StudyManagement/dto/MemberJoinReq.java
@@ -3,11 +3,15 @@ package mogakco.StudyManagement.dto;
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.Pattern;
+import lombok.AllArgsConstructor;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 import lombok.Setter;
 
 @Getter
 @Setter
+@AllArgsConstructor
+@NoArgsConstructor
 public class MemberJoinReq extends DTOReqCommon {
 
     @Schema(example = "user1")

--- a/src/main/java/mogakco/StudyManagement/repository/MemberScheduleRepository.java
+++ b/src/main/java/mogakco/StudyManagement/repository/MemberScheduleRepository.java
@@ -2,10 +2,13 @@ package mogakco.StudyManagement.repository;
 
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
+import java.util.List;
 
+import mogakco.StudyManagement.domain.Member;
 import mogakco.StudyManagement.domain.MemberSchedule;
 
 @Repository
 public interface MemberScheduleRepository extends JpaRepository<MemberSchedule, Long> {
 
+    List<MemberSchedule> findAllByMember(Member member);
 }

--- a/src/main/java/mogakco/StudyManagement/repository/StudyInfoRepository.java
+++ b/src/main/java/mogakco/StudyManagement/repository/StudyInfoRepository.java
@@ -1,0 +1,11 @@
+package mogakco.StudyManagement.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import mogakco.StudyManagement.domain.StudyInfo;
+
+@Repository
+public interface StudyInfoRepository extends JpaRepository<StudyInfo, Long> {
+
+}

--- a/src/main/java/mogakco/StudyManagement/repository/WakeUpRepository.java
+++ b/src/main/java/mogakco/StudyManagement/repository/WakeUpRepository.java
@@ -3,9 +3,12 @@ package mogakco.StudyManagement.repository;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
+import mogakco.StudyManagement.domain.Member;
 import mogakco.StudyManagement.domain.WakeUp;
 
 @Repository
 public interface WakeUpRepository extends JpaRepository<WakeUp, Long> {
+
+    WakeUp findByMember(Member member);
 
 }

--- a/src/main/java/mogakco/StudyManagement/service/member/MemberService.java
+++ b/src/main/java/mogakco/StudyManagement/service/member/MemberService.java
@@ -5,6 +5,7 @@ import org.springframework.security.core.userdetails.UsernameNotFoundException;
 
 import mogakco.StudyManagement.dto.DTOResCommon;
 import mogakco.StudyManagement.dto.MemberIdDuplReq;
+import mogakco.StudyManagement.dto.MemberInfoRes;
 import mogakco.StudyManagement.dto.MemberJoinReq;
 import mogakco.StudyManagement.dto.MemberLoginReq;
 import mogakco.StudyManagement.dto.MemberLoginRes;
@@ -18,4 +19,6 @@ public interface MemberService {
     DTOResCommon join(MemberJoinReq joinInfo, LoggingService lo);
 
     boolean isIdDuplicated(MemberIdDuplReq idInfo, LoggingService lo);
+
+    MemberInfoRes getMemberInfo(LoggingService lo);
 }

--- a/src/test/java/mogakco/StudyManagement/controller/MemberControllerTest.java
+++ b/src/test/java/mogakco/StudyManagement/controller/MemberControllerTest.java
@@ -17,6 +17,7 @@ import mogakco.StudyManagement.dto.MemberIdDuplReq;
 import mogakco.StudyManagement.dto.MemberJoinReq;
 import mogakco.StudyManagement.dto.MemberLoginReq;
 import mogakco.StudyManagement.service.member.impl.MemberServiceImpl;
+import mogakco.StudyManagement.util.DateUtil;
 import mogakco.StudyManagement.util.TestUtil;
 
 import org.springframework.beans.factory.annotation.Autowired;
@@ -56,13 +57,7 @@ public class MemberControllerTest {
     @WithMockUser(authorities = "ADMIN")
     @DisplayName("로그인 API 성공")
     void loginSuccess() throws Exception {
-        MemberLoginReq req = new MemberLoginReq();
-
-        req.setSendDate("string");
-        req.setSystemId("string");
-        req.setId(adminId);
-        req.setPassword(password);
-
+        MemberLoginReq req = new MemberLoginReq(DateUtil.getCurrentDateTime(), "SYS_01", adminId, password);
         String requestBodyJson = objectMapper.writeValueAsString(req);
 
         TestUtil.performPostRequest(mockMvc, LOGIN_URL, requestBodyJson, 200, 200);
@@ -72,13 +67,7 @@ public class MemberControllerTest {
     @WithMockUser(authorities = "ADMIN")
     @DisplayName("로그인 API 실패_not include sendDate")
     void loginFail_NotIncludeSendDate() throws Exception {
-        MemberLoginReq req = new MemberLoginReq();
-
-        req.setSendDate(null);
-        req.setSystemId("string");
-        req.setId(adminId);
-        req.setPassword(password);
-
+        MemberLoginReq req = new MemberLoginReq(null, "SYS_01", adminId, password);
         String requestBodyJson = objectMapper.writeValueAsString(req);
 
         TestUtil.performPostRequest(mockMvc, LOGIN_URL, requestBodyJson, 200, 404);
@@ -88,14 +77,8 @@ public class MemberControllerTest {
     @WithMockUser(authorities = "ADMIN")
     @DisplayName("로그인 API 실패_incorrect ID")
     void loginFail_IncorrectId() throws Exception {
-        MemberLoginReq req = new MemberLoginReq();
-
         String wrongId = "asdkawqwrjajsd12312";
-        req.setSendDate("string");
-        req.setSystemId("string");
-        req.setId(wrongId);
-        req.setPassword(password);
-
+        MemberLoginReq req = new MemberLoginReq(DateUtil.getCurrentDateTime(), "SYS_01", wrongId, password);
         String requestBodyJson = objectMapper.writeValueAsString(req);
 
         TestUtil.performPostRequest(mockMvc, LOGIN_URL, requestBodyJson, 200, 404);
@@ -105,14 +88,8 @@ public class MemberControllerTest {
     @WithMockUser(authorities = "ADMIN")
     @DisplayName("로그인 API 실패_incorrect PWD")
     void loginFail_IncorrectPwd() throws Exception {
-        MemberLoginReq req = new MemberLoginReq();
-
         String wrongPwd = "asdkawqwrjajsd12312";
-        req.setSendDate("string");
-        req.setSystemId("string");
-        req.setId(adminId);
-        req.setPassword(wrongPwd);
-
+        MemberLoginReq req = new MemberLoginReq(DateUtil.getCurrentDateTime(), "SYS_01", adminId, wrongPwd);
         String requestBodyJson = objectMapper.writeValueAsString(req);
 
         TestUtil.performPostRequest(mockMvc, LOGIN_URL, requestBodyJson, 200, 400);
@@ -125,18 +102,10 @@ public class MemberControllerTest {
     @DisplayName("회원가입 API 성공")
     @Sql("/ScheduleSetup.sql")
     void joinSuccess() throws Exception {
-        MemberJoinReq req = new MemberJoinReq();
-
-        req.setSendDate("string");
-        req.setSystemId("string");
-        req.setId("user1");
-        req.setPassword("password123!");
-        req.setName("HongGilDong");
-        req.setContact("01011112222");
-        req.setStudyName("모각코 스터디");
-        req.setEventName("AM1");
-        req.setWakeupTime("1530");
-
+        MemberJoinReq req = new MemberJoinReq("user1", "password123!", "HongGilDong", "01011112222", "모각코 스터디", "AM1",
+                "1530");
+        req.setSendDate(DateUtil.getCurrentDateTime());
+        req.setSystemId("SYS_01");
         String requestBodyJson = objectMapper.writeValueAsString(req);
 
         TestUtil.performPostRequest(mockMvc, JOIN_URL, requestBodyJson, 200, 200);
@@ -146,18 +115,10 @@ public class MemberControllerTest {
     @WithMockUser(authorities = "ADMIN")
     @DisplayName("회원가입 API 실패_not include sendDate")
     void joinFail_NotIncludeSendDate() throws Exception {
-        MemberJoinReq req = new MemberJoinReq();
-
+        MemberJoinReq req = new MemberJoinReq("user1", "password123!", "HongGilDong", "01011112222", "모각코 스터디", "AM1",
+                "1530");
         req.setSendDate(null);
-        req.setSystemId("string");
-        req.setId("user1");
-        req.setPassword("password123!");
-        req.setName("HongGilDong");
-        req.setContact("01011112222");
-        req.setStudyName("모각코 스터디");
-        req.setEventName("AM1");
-        req.setWakeupTime("1530");
-
+        req.setSystemId("SYS_01");
         String requestBodyJson = objectMapper.writeValueAsString(req);
 
         TestUtil.performPostRequest(mockMvc, JOIN_URL, requestBodyJson, 200, 404);
@@ -167,19 +128,11 @@ public class MemberControllerTest {
     @WithMockUser(authorities = "ADMIN")
     @DisplayName("회원가입 API 실패_invaild ID")
     void joinFail_InvalidId() throws Exception {
-        MemberJoinReq req = new MemberJoinReq();
         String invaildId = "";
-
-        req.setSendDate(null);
-        req.setSystemId("string");
-        req.setId(invaildId);
-        req.setPassword("password123!");
-        req.setName("HongGilDong");
-        req.setContact("01011112222");
-        req.setStudyName("모각코 스터디");
-        req.setEventName("AM1");
-        req.setWakeupTime("1530");
-
+        MemberJoinReq req = new MemberJoinReq(invaildId, "password123!", "HongGilDong", "01011112222", "모각코 스터디", "AM1",
+                "1530");
+        req.setSendDate(DateUtil.getCurrentDateTime());
+        req.setSystemId("SYS_01");
         String requestBodyJson = objectMapper.writeValueAsString(req);
 
         TestUtil.performPostRequest(mockMvc, JOIN_URL, requestBodyJson, 400, 400);
@@ -189,19 +142,11 @@ public class MemberControllerTest {
     @WithMockUser(authorities = "ADMIN")
     @DisplayName("회원가입 API 실패_invaild PWD")
     void joinFail_InvalidPwd() throws Exception {
-        MemberJoinReq req = new MemberJoinReq();
         String invaildPwd = "pwd";
-
-        req.setSendDate(null);
-        req.setSystemId("string");
-        req.setId("user99199");
-        req.setPassword(invaildPwd);
-        req.setName("HongGilDong");
-        req.setContact("01011112222");
-        req.setStudyName("모각코 스터디");
-        req.setEventName("AM1");
-        req.setWakeupTime("1530");
-
+        MemberJoinReq req = new MemberJoinReq("user1", invaildPwd, "HongGilDong", "01011112222", "모각코 스터디", "AM1",
+                "1530");
+        req.setSendDate(DateUtil.getCurrentDateTime());
+        req.setSystemId("SYS_01");
         String requestBodyJson = objectMapper.writeValueAsString(req);
 
         TestUtil.performPostRequest(mockMvc, JOIN_URL, requestBodyJson, 400, 400);
@@ -212,13 +157,12 @@ public class MemberControllerTest {
     @WithMockUser(authorities = "ADMIN")
     @DisplayName("아이디 중복 API 성공_중복")
     void idDuplicatedSuccess_dupl() throws Exception {
-        MemberIdDuplReq req = new MemberIdDuplReq();
-        req.setSendDate("string");
-        req.setSystemId("string");
-        req.setId(adminId);
-
+        MemberIdDuplReq req = new MemberIdDuplReq(adminId);
+        req.setSendDate(DateUtil.getCurrentDateTime());
+        req.setSystemId("SYS_01");
         String requestBodyJson = objectMapper.writeValueAsString(req);
         String expression = "duplicated";
+
         TestUtil.performPostRequest(mockMvc, ID_DUPLICATED_CHECK_URL, requestBodyJson, 200, true, expression);
     }
 
@@ -226,15 +170,13 @@ public class MemberControllerTest {
     @WithMockUser(authorities = "ADMIN")
     @DisplayName("아이디 중복 API 성공_미중복")
     void idDuplicatedSuccess_notDupl() throws Exception {
-        MemberIdDuplReq req = new MemberIdDuplReq();
-
         String wrongId = "aawadowajdqjdqwdas";
-        req.setSendDate("string");
-        req.setSystemId("string");
-        req.setId(wrongId);
-
+        MemberIdDuplReq req = new MemberIdDuplReq(wrongId);
+        req.setSendDate(DateUtil.getCurrentDateTime());
+        req.setSystemId("SYS_01");
         String requestBodyJson = objectMapper.writeValueAsString(req);
         String expression = "duplicated";
+
         TestUtil.performPostRequest(mockMvc, ID_DUPLICATED_CHECK_URL, requestBodyJson, 200, false, expression);
     }
 
@@ -242,13 +184,11 @@ public class MemberControllerTest {
     @WithMockUser(authorities = "ADMIN")
     @DisplayName("아이디 중복 API 실패_not include sendDate")
     void idDuplicatedFail_NotIncludeSendDate() throws Exception {
-        MemberIdDuplReq req = new MemberIdDuplReq();
-
+        MemberIdDuplReq req = new MemberIdDuplReq(adminId);
         req.setSendDate(null);
-        req.setSystemId("string");
-        req.setId(adminId);
-
+        req.setSystemId("SYS_01");
         String requestBodyJson = objectMapper.writeValueAsString(req);
+
         TestUtil.performPostRequest(mockMvc, ID_DUPLICATED_CHECK_URL, requestBodyJson, 200, 404);
     }
 

--- a/src/test/java/mogakco/StudyManagement/controller/MemberControllerTest.java
+++ b/src/test/java/mogakco/StudyManagement/controller/MemberControllerTest.java
@@ -1,5 +1,7 @@
 package mogakco.StudyManagement.controller;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.mockito.InjectMocks;
@@ -9,7 +11,9 @@ import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.context.jdbc.Sql;
 import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.MvcResult;
 import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.util.UriComponentsBuilder;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 
@@ -52,6 +56,7 @@ public class MemberControllerTest {
     private static final String LOGIN_URL = "/api/v1/login";
     private static final String JOIN_URL = "/api/v1/join";
     private static final String ID_DUPLICATED_CHECK_URL = "/api/v1/id-duplicated";
+    private static final String GET_MEMBER_INFO_URL = "/api/v1/member";
 
     @Test
     @WithMockUser(authorities = "ADMIN")
@@ -190,6 +195,32 @@ public class MemberControllerTest {
         String requestBodyJson = objectMapper.writeValueAsString(req);
 
         TestUtil.performPostRequest(mockMvc, ID_DUPLICATED_CHECK_URL, requestBodyJson, 200, 404);
+    }
+
+    /////////////////////////////////////////////////////////////////
+
+    @Test
+    @WithMockUser(username = "admin", authorities = { "ADMIN" })
+    @DisplayName("단일 회원정보 조회 성공")
+    public void getMemberInfo_Success() throws Exception {
+
+        UriComponentsBuilder uriBuilder = UriComponentsBuilder.fromUriString(GET_MEMBER_INFO_URL);
+
+        uriBuilder.queryParam("sendDate", DateUtil.getCurrentDateTime())
+                .queryParam("systemId", "SYS_01");
+
+        MvcResult result = TestUtil.performGetRequest(mockMvc, uriBuilder.toUriString(), 200);
+        System.out.println(result.getResponse().getContentAsString());
+        assertEquals(200, result.getResponse().getStatus());
+    }
+
+    @Test
+    @WithMockUser(username = "admin", authorities = { "ADMIN" })
+    @DisplayName("단일 회원정보 조회 성공_not include sendDate")
+    public void getMemberInfo_NotIncludeSendDate() throws Exception {
+
+        MvcResult result = TestUtil.performGetRequest(mockMvc, GET_MEMBER_INFO_URL, 200);
+        assertEquals(200, result.getResponse().getStatus());
     }
 
 }

--- a/src/test/java/mogakco/StudyManagement/controller/MemberControllerTest.java
+++ b/src/test/java/mogakco/StudyManagement/controller/MemberControllerTest.java
@@ -6,15 +6,10 @@ import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.http.MediaType;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.context.jdbc.Sql;
 import org.springframework.test.web.servlet.MockMvc;
-import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
-import org.springframework.test.web.servlet.result.MockMvcResultMatchers;
 import org.springframework.transaction.annotation.Transactional;
-
-import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 
@@ -22,6 +17,7 @@ import mogakco.StudyManagement.dto.MemberIdDuplReq;
 import mogakco.StudyManagement.dto.MemberJoinReq;
 import mogakco.StudyManagement.dto.MemberLoginReq;
 import mogakco.StudyManagement.service.member.impl.MemberServiceImpl;
+import mogakco.StudyManagement.util.TestUtil;
 
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
@@ -52,6 +48,10 @@ public class MemberControllerTest {
     @Value("${account.admin.password}")
     private String password;
 
+    private static final String LOGIN_URL = "/api/v1/login";
+    private static final String JOIN_URL = "/api/v1/join";
+    private static final String ID_DUPLICATED_CHECK_URL = "/api/v1/id-duplicated";
+
     @Test
     @WithMockUser(authorities = "ADMIN")
     @DisplayName("로그인 API 성공")
@@ -63,10 +63,9 @@ public class MemberControllerTest {
         req.setId(adminId);
         req.setPassword(password);
 
-        mockMvc.perform(MockMvcRequestBuilders.post("/api/v1/login")
-                .content(objectMapper.writeValueAsString(req))
-                .contentType(MediaType.APPLICATION_JSON))
-                .andExpect(MockMvcResultMatchers.status().isOk());
+        String requestBodyJson = objectMapper.writeValueAsString(req);
+
+        TestUtil.performPostRequest(mockMvc, LOGIN_URL, requestBodyJson, 200, 200);
     }
 
     @Test
@@ -80,11 +79,9 @@ public class MemberControllerTest {
         req.setId(adminId);
         req.setPassword(password);
 
-        mockMvc.perform(MockMvcRequestBuilders.post("/api/v1/login")
-                .content(objectMapper.writeValueAsString(req))
-                .contentType(MediaType.APPLICATION_JSON))
-                .andExpect(MockMvcResultMatchers.status().isOk())
-                .andExpect(jsonPath("$.retCode").value(404));
+        String requestBodyJson = objectMapper.writeValueAsString(req);
+
+        TestUtil.performPostRequest(mockMvc, LOGIN_URL, requestBodyJson, 200, 404);
     }
 
     @Test
@@ -99,11 +96,9 @@ public class MemberControllerTest {
         req.setId(wrongId);
         req.setPassword(password);
 
-        mockMvc.perform(MockMvcRequestBuilders.post("/api/v1/login")
-                .content(objectMapper.writeValueAsString(req))
-                .contentType(MediaType.APPLICATION_JSON))
-                .andExpect(MockMvcResultMatchers.status().isOk())
-                .andExpect(jsonPath("$.retCode").value(404));
+        String requestBodyJson = objectMapper.writeValueAsString(req);
+
+        TestUtil.performPostRequest(mockMvc, LOGIN_URL, requestBodyJson, 200, 404);
     }
 
     @Test
@@ -118,11 +113,9 @@ public class MemberControllerTest {
         req.setId(adminId);
         req.setPassword(wrongPwd);
 
-        mockMvc.perform(MockMvcRequestBuilders.post("/api/v1/login")
-                .content(objectMapper.writeValueAsString(req))
-                .contentType(MediaType.APPLICATION_JSON))
-                .andExpect(MockMvcResultMatchers.status().isOk())
-                .andExpect(jsonPath("$.retCode").value(400));
+        String requestBodyJson = objectMapper.writeValueAsString(req);
+
+        TestUtil.performPostRequest(mockMvc, LOGIN_URL, requestBodyJson, 200, 400);
     }
 
     /////////////////////////////////////////////////////////////////
@@ -144,11 +137,9 @@ public class MemberControllerTest {
         req.setEventName("AM1");
         req.setWakeupTime("1530");
 
-        mockMvc.perform(MockMvcRequestBuilders.post("/api/v1/join")
-                .content(objectMapper.writeValueAsString(req))
-                .contentType(MediaType.APPLICATION_JSON))
-                .andExpect(MockMvcResultMatchers.status().isOk())
-                .andExpect(jsonPath("$.retCode").value(200));
+        String requestBodyJson = objectMapper.writeValueAsString(req);
+
+        TestUtil.performPostRequest(mockMvc, JOIN_URL, requestBodyJson, 200, 200);
     }
 
     @Test
@@ -167,11 +158,9 @@ public class MemberControllerTest {
         req.setEventName("AM1");
         req.setWakeupTime("1530");
 
-        mockMvc.perform(MockMvcRequestBuilders.post("/api/v1/join")
-                .content(objectMapper.writeValueAsString(req))
-                .contentType(MediaType.APPLICATION_JSON))
-                .andExpect(MockMvcResultMatchers.status().isOk())
-                .andExpect(jsonPath("$.retCode").value(404));
+        String requestBodyJson = objectMapper.writeValueAsString(req);
+
+        TestUtil.performPostRequest(mockMvc, JOIN_URL, requestBodyJson, 200, 404);
     }
 
     @Test
@@ -191,11 +180,9 @@ public class MemberControllerTest {
         req.setEventName("AM1");
         req.setWakeupTime("1530");
 
-        mockMvc.perform(MockMvcRequestBuilders.post("/api/v1/join")
-                .content(objectMapper.writeValueAsString(req))
-                .contentType(MediaType.APPLICATION_JSON))
-                .andExpect(MockMvcResultMatchers.status().isBadRequest())
-                .andExpect(jsonPath("$.retCode").value(400));
+        String requestBodyJson = objectMapper.writeValueAsString(req);
+
+        TestUtil.performPostRequest(mockMvc, JOIN_URL, requestBodyJson, 400, 400);
     }
 
     @Test
@@ -215,11 +202,9 @@ public class MemberControllerTest {
         req.setEventName("AM1");
         req.setWakeupTime("1530");
 
-        mockMvc.perform(MockMvcRequestBuilders.post("/api/v1/join")
-                .content(objectMapper.writeValueAsString(req))
-                .contentType(MediaType.APPLICATION_JSON))
-                .andExpect(MockMvcResultMatchers.status().isBadRequest())
-                .andExpect(jsonPath("$.retCode").value(400));
+        String requestBodyJson = objectMapper.writeValueAsString(req);
+
+        TestUtil.performPostRequest(mockMvc, JOIN_URL, requestBodyJson, 400, 400);
     }
 
     /////////////////////////////////////////////////////////////////
@@ -232,11 +217,9 @@ public class MemberControllerTest {
         req.setSystemId("string");
         req.setId(adminId);
 
-        mockMvc.perform(MockMvcRequestBuilders.post("/api/v1/id-duplicated")
-                .content(objectMapper.writeValueAsString(req))
-                .contentType(MediaType.APPLICATION_JSON))
-                .andExpect(MockMvcResultMatchers.status().isOk())
-                .andExpect(jsonPath("$.duplicated").value(true));
+        String requestBodyJson = objectMapper.writeValueAsString(req);
+        String expression = "duplicated";
+        TestUtil.performPostRequest(mockMvc, ID_DUPLICATED_CHECK_URL, requestBodyJson, 200, true, expression);
     }
 
     @Test
@@ -250,11 +233,9 @@ public class MemberControllerTest {
         req.setSystemId("string");
         req.setId(wrongId);
 
-        mockMvc.perform(MockMvcRequestBuilders.post("/api/v1/id-duplicated")
-                .content(objectMapper.writeValueAsString(req))
-                .contentType(MediaType.APPLICATION_JSON))
-                .andExpect(MockMvcResultMatchers.status().isOk())
-                .andExpect(jsonPath("$.duplicated").value(false));
+        String requestBodyJson = objectMapper.writeValueAsString(req);
+        String expression = "duplicated";
+        TestUtil.performPostRequest(mockMvc, ID_DUPLICATED_CHECK_URL, requestBodyJson, 200, false, expression);
     }
 
     @Test
@@ -267,11 +248,8 @@ public class MemberControllerTest {
         req.setSystemId("string");
         req.setId(adminId);
 
-        mockMvc.perform(MockMvcRequestBuilders.post("/api/v1/id-duplicated")
-                .content(objectMapper.writeValueAsString(req))
-                .contentType(MediaType.APPLICATION_JSON))
-                .andExpect(MockMvcResultMatchers.status().isOk())
-                .andExpect(jsonPath("$.retCode").value(404));
+        String requestBodyJson = objectMapper.writeValueAsString(req);
+        TestUtil.performPostRequest(mockMvc, ID_DUPLICATED_CHECK_URL, requestBodyJson, 200, 404);
     }
 
 }

--- a/src/test/java/mogakco/StudyManagement/controller/MemberControllerTest.java
+++ b/src/test/java/mogakco/StudyManagement/controller/MemberControllerTest.java
@@ -137,7 +137,7 @@ public class MemberControllerTest {
         req.setSendDate("string");
         req.setSystemId("string");
         req.setId("user1");
-        req.setPassword("pwd");
+        req.setPassword("password123!");
         req.setName("HongGilDong");
         req.setContact("01011112222");
         req.setStudyName("모각코 스터디");
@@ -160,7 +160,7 @@ public class MemberControllerTest {
         req.setSendDate(null);
         req.setSystemId("string");
         req.setId("user1");
-        req.setPassword("pwd");
+        req.setPassword("password123!");
         req.setName("HongGilDong");
         req.setContact("01011112222");
         req.setStudyName("모각코 스터디");
@@ -172,6 +172,54 @@ public class MemberControllerTest {
                 .contentType(MediaType.APPLICATION_JSON))
                 .andExpect(MockMvcResultMatchers.status().isOk())
                 .andExpect(jsonPath("$.retCode").value(404));
+    }
+
+    @Test
+    @WithMockUser(authorities = "ADMIN")
+    @DisplayName("회원가입 API 실패_invaild ID")
+    void joinFail_InvalidId() throws Exception {
+        MemberJoinReq req = new MemberJoinReq();
+        String invaildId = "";
+
+        req.setSendDate(null);
+        req.setSystemId("string");
+        req.setId(invaildId);
+        req.setPassword("password123!");
+        req.setName("HongGilDong");
+        req.setContact("01011112222");
+        req.setStudyName("모각코 스터디");
+        req.setEventName("AM1");
+        req.setWakeupTime("1530");
+
+        mockMvc.perform(MockMvcRequestBuilders.post("/api/v1/join")
+                .content(objectMapper.writeValueAsString(req))
+                .contentType(MediaType.APPLICATION_JSON))
+                .andExpect(MockMvcResultMatchers.status().isBadRequest())
+                .andExpect(jsonPath("$.retCode").value(400));
+    }
+
+    @Test
+    @WithMockUser(authorities = "ADMIN")
+    @DisplayName("회원가입 API 실패_invaild PWD")
+    void joinFail_InvalidPwd() throws Exception {
+        MemberJoinReq req = new MemberJoinReq();
+        String invaildPwd = "pwd";
+
+        req.setSendDate(null);
+        req.setSystemId("string");
+        req.setId("user99199");
+        req.setPassword(invaildPwd);
+        req.setName("HongGilDong");
+        req.setContact("01011112222");
+        req.setStudyName("모각코 스터디");
+        req.setEventName("AM1");
+        req.setWakeupTime("1530");
+
+        mockMvc.perform(MockMvcRequestBuilders.post("/api/v1/join")
+                .content(objectMapper.writeValueAsString(req))
+                .contentType(MediaType.APPLICATION_JSON))
+                .andExpect(MockMvcResultMatchers.status().isBadRequest())
+                .andExpect(jsonPath("$.retCode").value(400));
     }
 
     /////////////////////////////////////////////////////////////////

--- a/src/test/java/mogakco/StudyManagement/util/TestUtil.java
+++ b/src/test/java/mogakco/StudyManagement/util/TestUtil.java
@@ -13,13 +13,35 @@ import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
 public class TestUtil {
 
     public static void performPostRequest(MockMvc mockMvc, String url, String requestBodyJson, int expectedStatus,
-            Integer expectedRetCode)
+            Integer expected)
             throws Exception {
         mockMvc.perform(post(url)
                 .contentType(MediaType.APPLICATION_JSON)
                 .content(requestBodyJson))
                 .andExpect(status().is(expectedStatus))
-                .andExpect(expectedRetCode != null ? jsonPath("$.retCode").value(expectedRetCode) : null);
+                .andExpect(expected != null ? jsonPath("$.retCode").value(expected) : null);
+    }
+
+    // Method OverLoading
+    public static void performPostRequest(MockMvc mockMvc, String url, String requestBodyJson, int expectedStatus,
+            Boolean expected, String expression)
+            throws Exception {
+        mockMvc.perform(post(url)
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(requestBodyJson))
+                .andExpect(status().is(expectedStatus))
+                .andExpect(expected != null ? jsonPath("$." + expression).value(expected) : null);
+    }
+
+    // Method OverLoading
+    public static void performPostRequest(MockMvc mockMvc, String url, String requestBodyJson, int expectedStatus,
+            String expected, String expression)
+            throws Exception {
+        mockMvc.perform(post(url)
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(requestBodyJson))
+                .andExpect(status().is(expectedStatus))
+                .andExpect(expected != null ? jsonPath("$." + expression).value(expected) : null);
     }
 
     public static MvcResult performGetRequest(MockMvc mockMvc, String url, int expectedStatus) throws Exception {


### PR DESCRIPTION
하기 작업 내용 참고 부탁드립니다.

[feat]
1. 단일 회원 정보 조회 API 구현(My Page에서 활용될 API)

[fix]
1. 회원가입 API 중 requestBody 내 id, password 유효성 검사 + 관련 테스트 코드 작성

[refactor]
1. TestUtil.java 활용하여 MemberControllerTest.java 리팩토링 및 TestUtil 오버로딩 메소드 추가
2. MemberControllerTest.java 내 사용되는 요청 객체 생성자를 통해 데이터 셋 하도록 변경


*구현한 단일 회원 정보 조회 API는 특정 정보가 없다고 해서 에러를 발생하는게 아닌 있는 정보라도 리턴할 수 있도록 개발하였습니다.