### PR TITLE
Task retrieve like and comment cnt in post get api

### DIFF
--- a/mysql/ERD.md
+++ b/mysql/ERD.md
@@ -49,7 +49,6 @@
 | member_id   | Foreign Key | Long          | 게시자 ID     |
 | title       |             | String(60)    | 게시글 제목   |
 | content     |             | String(20000) | 게시글 내용   |
-| view_cnt    |             | Integer       | 조회 수       |
 | created_at  |             | String        | 생성 날짜     |
 | updated_at  |             | String        | 업데이트 날짜 |
 

--- a/src/main/java/mogakco/StudyManagement/domain/Post.java
+++ b/src/main/java/mogakco/StudyManagement/domain/Post.java
@@ -38,9 +38,6 @@ public class Post {
     @Column(length = 20000, nullable = false)
     private String content;
 
-    @Column(name = "view_cnt", nullable = false)
-    private Integer viewCnt;
-
     @Column(nullable = false)
     private String createdAt;
 

--- a/src/main/java/mogakco/StudyManagement/dto/PostDetail.java
+++ b/src/main/java/mogakco/StudyManagement/dto/PostDetail.java
@@ -6,27 +6,27 @@ import mogakco.StudyManagement.domain.Post;
 
 @Getter
 @Setter
-public class PostList {
+public class PostDetail {
+    private String memberName;
 
     private Integer likes;
 
     private String title;
 
-    private String memberName;
-
-    private Integer commentCnt;
+    private String content;
 
     private String createdAt;
 
     private String updatedAt;
 
-    public PostList(Post post, Integer likes, Integer commentCnt) {
-        this.title = post.getTitle();
+    public PostDetail(Post post, Integer likes) {
+
         this.memberName = post.getMember().getName();
+        this.title = post.getTitle();
+        this.content = post.getContent();
         this.createdAt = post.getCreatedAt();
         this.updatedAt = post.getUpdatedAt();
         this.likes = likes;
-        this.commentCnt = commentCnt;
-    }
 
+    }
 }

--- a/src/main/java/mogakco/StudyManagement/dto/PostDetailRes.java
+++ b/src/main/java/mogakco/StudyManagement/dto/PostDetailRes.java
@@ -9,12 +9,11 @@ import lombok.Setter;
 @NoArgsConstructor
 public class PostDetailRes extends DTOResCommon {
 
-    private PostList postList;
+    private PostDetail postDetail;
 
-    public PostDetailRes(String systemId, Integer retCode, String retMsg, PostList postList) {
-
+    public PostDetailRes(String systemId, Integer retCode, String retMsg, PostDetail postDetail) {
         super(systemId, retCode, retMsg);
-        this.postList = postList;
+        this.postDetail = postDetail;
     }
 
 }

--- a/src/main/java/mogakco/StudyManagement/repository/PostCommentRepository.java
+++ b/src/main/java/mogakco/StudyManagement/repository/PostCommentRepository.java
@@ -9,4 +9,6 @@ import mogakco.StudyManagement.domain.PostComment;
 @Repository
 public interface PostCommentRepository extends JpaRepository<PostComment, Long>, JpaSpecificationExecutor<PostComment> {
 
+    Integer countByPostPostId(Long postId);
+
 }

--- a/src/main/java/mogakco/StudyManagement/repository/PostLikeRepository.java
+++ b/src/main/java/mogakco/StudyManagement/repository/PostLikeRepository.java
@@ -9,4 +9,6 @@ import mogakco.StudyManagement.domain.PostLike;
 @Repository
 public interface PostLikeRepository extends JpaRepository<PostLike, Long>, JpaSpecificationExecutor<PostLike> {
 
+    Integer countByPostPostId(Long postId);
+
 }

--- a/src/test/java/mogakco/StudyManagement/controller/PostControllerTest.java
+++ b/src/test/java/mogakco/StudyManagement/controller/PostControllerTest.java
@@ -1,5 +1,6 @@
 package mogakco.StudyManagement.controller;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import org.junit.jupiter.api.DisplayName;
@@ -172,7 +173,11 @@ public class PostControllerTest {
 
         for (JsonNode element : responseBody.path("content")) {
             String title = element.path("title").asText();
+            int likeCnt = element.path("likes").asInt();
+            int commentCnt = element.path("commentCnt").asInt();
             assertTrue(title.startsWith("post2"));
+            assertEquals(likeCnt, 1);
+            assertEquals(commentCnt, 1);
             break;
         }
     }
@@ -227,7 +232,7 @@ public class PostControllerTest {
                 null, "GET", 200, 200);
 
         JsonNode responseBody = objectMapper.readTree(result.getResponse().getContentAsString());
-        String title = responseBody.path("postList").path("title").asText();
+        String title = responseBody.path("postDetail").path("title").asText();
         assertTrue(title.startsWith("post"));
     }
 

--- a/src/test/resources/post/PostCommentSetup.sql
+++ b/src/test/resources/post/PostCommentSetup.sql
@@ -5,9 +5,8 @@ VALUES
 ('010-1111-1111', '20240112222007395', '20240112222007395', 'PostUser2', 'PostUser2', '$2a$10$LFyW8UyygbwOdyVODxN/lOMVo.Euubxgx9F7c7tX49bqHOgOXE/Z6', 'USER');
 
 
-INSERT INTO study.post (view_cnt, member_id, title, content, created_at, updated_at)
+INSERT INTO study.post (member_id, title, content, created_at, updated_at)
 SELECT
-    0,
     (SELECT member_id FROM member WHERE id = 'PostUser'),
     title,
     content,

--- a/src/test/resources/post/PostLikeSetup.sql
+++ b/src/test/resources/post/PostLikeSetup.sql
@@ -4,9 +4,8 @@ VALUES
 ('010-1111-1111', '20240112222007395', '20240112222007395', 'PostUser', 'PostUser', '$2a$10$LFyW8UyygbwOdyVODxN/lOMVo.Euubxgx9F7c7tX49bqHOgOXE/Z6', 'USER'),
 ('010-1111-1111', '20240112222007395', '20240112222007395', 'PostUser2', 'PostUser2', '$2a$10$LFyW8UyygbwOdyVODxN/lOMVo.Euubxgx9F7c7tX49bqHOgOXE/Z6', 'USER');
 
-INSERT INTO study.post (view_cnt, member_id, title, content, created_at, updated_at)
+INSERT INTO study.post (member_id, title, content, created_at, updated_at)
 SELECT
-    0,
     (SELECT member_id FROM member WHERE id = 'PostUser'),
     title,
     content,

--- a/src/test/resources/post/PostSetup.sql
+++ b/src/test/resources/post/PostSetup.sql
@@ -5,9 +5,8 @@ VALUES
 ('010-1111-1111', '20240112222007395', '20240112222007395', 'PostUser2', 'PostUser2', '$2a$10$LFyW8UyygbwOdyVODxN/lOMVo.Euubxgx9F7c7tX49bqHOgOXE/Z6', 'USER');
 
 
-INSERT INTO study.post (view_cnt, member_id, title, content, created_at, updated_at)
+INSERT INTO study.post (member_id, title, content, created_at, updated_at)
 SELECT
-    0,
     (SELECT member_id FROM member WHERE id = 'PostUser'),
     title,
     content,
@@ -22,3 +21,27 @@ FROM (
     UNION ALL
     SELECT 'post4' AS title, 'content4' AS content
 ) AS data;
+
+
+
+INSERT INTO study.post_like
+(member_id, post_id)
+VALUES
+(
+    (SELECT member_id FROM member WHERE id = 'PostUser2'),
+    (SELECT post_id FROM post WHERE title = 'post2')
+
+);
+
+INSERT INTO study.post_comment
+( member_id, parent_comment_id, post_id, content, created_at, updated_at)
+VALUES 
+(   
+    (SELECT member_id FROM member WHERE id = 'PostUser2'),
+    null,
+    (select  post_id from post
+    where title  = 'post2'),
+    'comment1',
+    DATE_FORMAT(NOW(6), '%Y%m%d24%H%i%s%f'),
+    DATE_FORMAT(NOW(6), '%Y%m%d24%H%i%s%f')
+);


### PR DESCRIPTION
안녕하세요 @dayeon-dayeon !

좋아요 수 조회 API를 만드는 대신 게시글 목록/상세 조회 시 좋아요 수도 가져오도록 기존 API를 수정하였습니다!
아래 사진에서 GET API 2가지가 수정되었습니다
![image](https://github.com/ZinnaChoi/Study-Management/assets/142554606/3e086cde-0e98-4140-aeb3-dfd196d6569b)

또한 Post 테이블에서 더 이상 사용되지 않는 view_cnt 컬럼을 없앴으니,
`application.properties`에서 ddl-auto: create으로 바꾼 뒤 1번 백앤드를 실행시킨 뒤, 다시 update로 롤백해주시면 됩니다!!

 `PostControllerTest.java`에서 테스트 확인 가능합니다.
감사합니다!