### PR TITLE
Task admin study delete api

### DIFF
--- a/src/main/java/mogakco/StudyManagement/config/SecurityConfig.java
+++ b/src/main/java/mogakco/StudyManagement/config/SecurityConfig.java
@@ -38,6 +38,7 @@ public class SecurityConfig {
                 .requestMatchers("/swagger-ui.html", "/v1/api-docs/**", "/swagger-ui/**", "/swagger-resources/**")
                 .permitAll() // swagger 경로
                 // 접근 허용
+                .requestMatchers("/api/v1/study/**").hasAuthority("ADMIN") // admin 권한만 접근 가능!
                 .requestMatchers("/api/v1/**").hasAnyAuthority("ADMIN", "USER") // 모든 권한 api/user/** 접근 가능!
                 .anyRequest().authenticated()); // 그 외 요청들은 인증된 사용자(유효한 JWT를 가지고있는)만 접근 가능
         // 로그인 필터 전에 동작

--- a/src/main/java/mogakco/StudyManagement/controller/StudyController.java
+++ b/src/main/java/mogakco/StudyManagement/controller/StudyController.java
@@ -80,7 +80,7 @@ public class StudyController extends CommonController {
         return result;
     }
 
-    @Operation(summary = "스터디 정보 수정", description = "스터디 정보(스터디 이름, 로고, 스케줄) 수정")
+    @Operation(summary = "스터디 정보 삭제", description = "스터디 정보(스터디 이름, 로고, 스케줄) 삭제")
     @SecurityRequirement(name = "bearer-key")
     @DeleteMapping(value = "/study/{studyname}")
     public DTOResCommon deleteStudy(HttpServletRequest request,

--- a/src/main/java/mogakco/StudyManagement/controller/StudyController.java
+++ b/src/main/java/mogakco/StudyManagement/controller/StudyController.java
@@ -60,7 +60,7 @@ public class StudyController extends CommonController {
 
     @Operation(summary = "스터디 정보 수정", description = "스터디 정보(스터디 이름, 로고, 스케줄) 수정")
     @SecurityRequirement(name = "bearer-key")
-    @PutMapping(value = "/studyinfo", consumes = MediaType.MULTIPART_FORM_DATA_VALUE, produces = MediaType.APPLICATION_JSON_VALUE)
+    @PutMapping(value = "/study", consumes = MediaType.MULTIPART_FORM_DATA_VALUE, produces = MediaType.APPLICATION_JSON_VALUE)
     public DTOResCommon updateStudy(HttpServletRequest request,
             @Valid @RequestPart(value = "studyReq") @Parameter(schema = @Schema(type = "string", format = "binary")) StudyReq studyReq,
             @Parameter(description = "이미지 파일") @RequestPart(name = "logo file", required = false) MultipartFile imageFile) {

--- a/src/main/java/mogakco/StudyManagement/controller/StudyController.java
+++ b/src/main/java/mogakco/StudyManagement/controller/StudyController.java
@@ -1,6 +1,8 @@
 package mogakco.StudyManagement.controller;
 
 import org.springframework.http.MediaType;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -67,6 +69,27 @@ public class StudyController extends CommonController {
         try {
             startAPI(lo, studyReq);
             result = studyService.updateStudy(studyReq, imageFile, lo);
+        } catch (Exception e) {
+            e.printStackTrace();
+            result = new DTOResCommon(systemId, ErrorCode.INTERNAL_ERROR.getCode(),
+                    ErrorCode.INTERNAL_ERROR.getMessage());
+        } finally {
+            endAPI(request, ErrorCode.OK, lo, result);
+        }
+
+        return result;
+    }
+
+    @Operation(summary = "스터디 정보 수정", description = "스터디 정보(스터디 이름, 로고, 스케줄) 수정")
+    @SecurityRequirement(name = "bearer-key")
+    @DeleteMapping(value = "/study/{studyname}")
+    public DTOResCommon deleteStudy(HttpServletRequest request,
+            @PathVariable(name = "studyname", required = true) String studyName) {
+        DTOResCommon result = new DTOResCommon();
+
+        try {
+            startAPI(lo, null);
+            result = studyService.deleteStudy(studyName, lo);
         } catch (Exception e) {
             e.printStackTrace();
             result = new DTOResCommon(systemId, ErrorCode.INTERNAL_ERROR.getCode(),

--- a/src/main/java/mogakco/StudyManagement/controller/StudyController.java
+++ b/src/main/java/mogakco/StudyManagement/controller/StudyController.java
@@ -82,14 +82,14 @@ public class StudyController extends CommonController {
 
     @Operation(summary = "스터디 정보 삭제", description = "스터디 정보(스터디 이름, 로고, 스케줄) 삭제")
     @SecurityRequirement(name = "bearer-key")
-    @DeleteMapping(value = "/study/{studyname}")
+    @DeleteMapping(value = "/study/{studyid}")
     public DTOResCommon deleteStudy(HttpServletRequest request,
-            @PathVariable(name = "studyname", required = true) String studyName) {
+            @PathVariable(name = "studyid", required = true) Long studyId) {
         DTOResCommon result = new DTOResCommon();
 
         try {
             startAPI(lo, null);
-            result = studyService.deleteStudy(studyName, lo);
+            result = studyService.deleteStudy(studyId, lo);
         } catch (Exception e) {
             e.printStackTrace();
             result = new DTOResCommon(systemId, ErrorCode.INTERNAL_ERROR.getCode(),

--- a/src/main/java/mogakco/StudyManagement/domain/AbsentSchedule.java
+++ b/src/main/java/mogakco/StudyManagement/domain/AbsentSchedule.java
@@ -2,6 +2,9 @@ package mogakco.StudyManagement.domain;
 
 import java.util.Objects;
 
+import org.hibernate.annotations.OnDelete;
+import org.hibernate.annotations.OnDeleteAction;
+
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.FetchType;
@@ -35,6 +38,7 @@ public class AbsentSchedule {
 
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "schedule_id", nullable = false)
+    @OnDelete(action = OnDeleteAction.CASCADE)
     private Schedule schedule;
 
     @Column(nullable = false)

--- a/src/main/java/mogakco/StudyManagement/domain/MemberSchedule.java
+++ b/src/main/java/mogakco/StudyManagement/domain/MemberSchedule.java
@@ -1,5 +1,8 @@
 package mogakco.StudyManagement.domain;
 
+import org.hibernate.annotations.OnDelete;
+import org.hibernate.annotations.OnDeleteAction;
+
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.FetchType;
@@ -13,7 +16,6 @@ import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
-import lombok.Setter;
 
 @Entity
 @Builder
@@ -33,6 +35,7 @@ public class MemberSchedule {
 
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "schedule_id", nullable = false)
+    @OnDelete(action = OnDeleteAction.CASCADE)
     private Schedule schedule;
 
     @Column(nullable = false)

--- a/src/main/java/mogakco/StudyManagement/domain/StudyInfo.java
+++ b/src/main/java/mogakco/StudyManagement/domain/StudyInfo.java
@@ -24,7 +24,7 @@ public class StudyInfo {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long studyId;
 
-    @Column(nullable = false)
+    @Column(nullable = false, unique = true)
     private String studyName;
 
     @Lob

--- a/src/main/java/mogakco/StudyManagement/dto/StudyReq.java
+++ b/src/main/java/mogakco/StudyManagement/dto/StudyReq.java
@@ -16,6 +16,9 @@ public class StudyReq extends DTOReqCommon {
     @Schema(example = "모각코 스터디")
     private String studyName;
 
+    @Schema(example = "변경할 스터디 이름", description = "스터디 정보 수정 API에 사용")
+    private String updateStudyName;
+
     private List<ScheduleReq> schedules;
 
     public StudyReq(String studyName,

--- a/src/main/java/mogakco/StudyManagement/repository/StudyInfoRepository.java
+++ b/src/main/java/mogakco/StudyManagement/repository/StudyInfoRepository.java
@@ -10,4 +10,6 @@ public interface StudyInfoRepository extends JpaRepository<StudyInfo, Long> {
     Boolean existsByStudyName(String studyName);
 
     StudyInfo findByStudyName(String studyName);
+
+    StudyInfo findByStudyId(Long studyId);
 }

--- a/src/main/java/mogakco/StudyManagement/service/study/StudyService.java
+++ b/src/main/java/mogakco/StudyManagement/service/study/StudyService.java
@@ -15,6 +15,6 @@ public interface StudyService {
         DTOResCommon updateStudy(StudyReq studyCreateReq, MultipartFile imageFile, LoggingService lo)
                         throws IOException;
 
-        DTOResCommon deleteStudy(String studyName, LoggingService lo);
+        DTOResCommon deleteStudy(Long studyId, LoggingService lo);
 
 }

--- a/src/main/java/mogakco/StudyManagement/service/study/StudyService.java
+++ b/src/main/java/mogakco/StudyManagement/service/study/StudyService.java
@@ -15,4 +15,6 @@ public interface StudyService {
         DTOResCommon updateStudy(StudyReq studyCreateReq, MultipartFile imageFile, LoggingService lo)
                         throws IOException;
 
+        DTOResCommon deleteStudy(String studyName, LoggingService lo);
+
 }

--- a/src/main/java/mogakco/StudyManagement/service/study/impl/StudyServiceImpl.java
+++ b/src/main/java/mogakco/StudyManagement/service/study/impl/StudyServiceImpl.java
@@ -151,4 +151,25 @@ public class StudyServiceImpl implements StudyService {
 
                 return new DTOResCommon(systemId, ErrorCode.OK.getCode(), ErrorCode.OK.getMessage());
         }
+
+        @Override
+        @Transactional
+        public DTOResCommon deleteStudy(String studyName, LoggingService lo) {
+
+                lo.setDBStart();
+                StudyInfo studyInfo = studyInfoRepository.findByStudyName(studyName);
+                lo.setDBEnd();
+                if (studyInfo == null) {
+                        return ExceptionUtil.handleException(
+                                        new NotFoundException(studyName + " 이름으로 등록된 스터디가 존재하지 않아 삭제할 수 없습니다."));
+                }
+
+                // study_info 및 schedule 삭제(member_schedule, absent_schedule 테이블도 cascade 삭제됨)
+                lo.setDBStart();
+                studyInfoRepository.delete(studyInfo);
+                scheduleRepository.deleteAll();
+                lo.setDBEnd();
+
+                return new DTOResCommon(systemId, ErrorCode.OK.getCode(), ErrorCode.OK.getMessage());
+        }
 }

--- a/src/main/java/mogakco/StudyManagement/service/study/impl/StudyServiceImpl.java
+++ b/src/main/java/mogakco/StudyManagement/service/study/impl/StudyServiceImpl.java
@@ -167,14 +167,14 @@ public class StudyServiceImpl implements StudyService {
 
         @Override
         @Transactional
-        public DTOResCommon deleteStudy(String studyName, LoggingService lo) {
+        public DTOResCommon deleteStudy(Long studyId, LoggingService lo) {
 
                 lo.setDBStart();
-                StudyInfo studyInfo = studyInfoRepository.findByStudyName(studyName);
+                StudyInfo studyInfo = studyInfoRepository.findByStudyId(studyId);
                 lo.setDBEnd();
                 if (studyInfo == null) {
                         return ExceptionUtil.handleException(
-                                        new NotFoundException(studyName + " 이름으로 등록된 스터디가 존재하지 않아 삭제할 수 없습니다."));
+                                        new NotFoundException(studyId + " 아이디로 등록된 스터디가 존재하지 않아 삭제할 수 없습니다."));
                 }
 
                 // study_info 및 schedule 삭제(member_schedule, absent_schedule 테이블도 cascade 삭제됨)

--- a/src/test/java/mogakco/StudyManagement/controller/StudyControllerTest.java
+++ b/src/test/java/mogakco/StudyManagement/controller/StudyControllerTest.java
@@ -18,6 +18,7 @@ import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.context.jdbc.Sql;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.util.UriComponentsBuilder;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 
@@ -51,6 +52,7 @@ public class StudyControllerTest {
 
         private static final String CREATE_STUDY_API_URL = "/api/v1/study";
         private static final String UPDATE_STUDY_API_URL = "/api/v1/studyinfo";
+        private static final String DELETE_STUDY_API_URL = "/api/v1/study";
 
         @Test
         @WithMockUser(username = "admin", authorities = { "ADMIN" })
@@ -59,11 +61,11 @@ public class StudyControllerTest {
 
                 MockMultipartFile file = new MockMultipartFile("logo file", "logo.png", "image/png",
                                 "yourImageData".getBytes());
-                ScheduleReq scheduleCreateReq = new ScheduleReq("없는 스케줄 이름123123", "13:00", "14:00");
+                ScheduleReq scheduleCreateReq = new ScheduleReq("NotExistScheduleName", "13:00", "14:00");
                 List<ScheduleReq> schedules = Collections.singletonList(scheduleCreateReq);
 
                 StudyReq studyReq = new StudyReq(
-                                "없는 스터디 이름123123", "10.10.10.110", "admin", "password", schedules);
+                                "NotExistStudyName", "10.10.10.110", "admin", "password", schedules);
                 studyReq.setSendDate(DateUtil.getCurrentDateTime());
                 studyReq.setSystemId("SYS_01");
                 String requestBodyJson = objectMapper.writeValueAsString(studyReq);
@@ -83,11 +85,11 @@ public class StudyControllerTest {
 
                 MockMultipartFile file = new MockMultipartFile("logo file", "logo.png", "image/png",
                                 "yourImageData".getBytes());
-                ScheduleReq scheduleCreateReq = new ScheduleReq("없는 스케줄 이름123123", "13:00", "14:00");
+                ScheduleReq scheduleCreateReq = new ScheduleReq("NotExistScheduleName", "13:00", "14:00");
                 List<ScheduleReq> schedules = Collections.singletonList(scheduleCreateReq);
 
                 StudyReq studyReq = new StudyReq(
-                                "없는 스터디 이름123123", "10.10.10.110", "admin", "password", schedules);
+                                "NotExistStudyName", "10.10.10.110", "admin", "password", schedules);
                 studyReq.setSendDate(DateUtil.getCurrentDateTime());
                 studyReq.setSystemId("SYS_01");
                 String requestBodyJson = objectMapper.writeValueAsString(studyReq);
@@ -107,11 +109,11 @@ public class StudyControllerTest {
 
                 MockMultipartFile file = new MockMultipartFile("logo file", "logo.png", "image/png",
                                 "yourImageData".getBytes());
-                ScheduleReq scheduleCreateReq = new ScheduleReq("없는 스케줄 이름123123", "13:00", "14:00");
+                ScheduleReq scheduleCreateReq = new ScheduleReq("NotExistScheduleName", "13:00", "14:00");
                 List<ScheduleReq> schedules = Collections.singletonList(scheduleCreateReq);
 
                 StudyReq studyReq = new StudyReq(
-                                "없는 스터디 이름123123", "10.10.10.110", "admin", "password", schedules);
+                                "NotExistStudyName", "10.10.10.110", "admin", "password", schedules);
                 studyReq.setSendDate(DateUtil.getCurrentDateTime());
                 studyReq.setSystemId("SYS_01");
                 String requestBodyJson = objectMapper.writeValueAsString(studyReq);
@@ -131,11 +133,11 @@ public class StudyControllerTest {
 
                 MockMultipartFile file = new MockMultipartFile("logo file", "logo.png", "image/png",
                                 "yourImageData".getBytes());
-                ScheduleReq scheduleUpdateReq = new ScheduleReq("없는 스케줄 이름123123", "13:00", "14:00");
+                ScheduleReq scheduleUpdateReq = new ScheduleReq("NotExistScheduleName", "13:00", "14:00");
                 List<ScheduleReq> schedules = Collections.singletonList(scheduleUpdateReq);
 
                 StudyReq studyReq = new StudyReq(
-                                "없는 스터디 이름123123", "10.10.10.110", "admin", "password", schedules);
+                                "NotExistStudyName", "10.10.10.110", "admin", "password", schedules);
                 studyReq.setSendDate(DateUtil.getCurrentDateTime());
                 studyReq.setSystemId("SYS_01");
                 String requestBodyJson = objectMapper.writeValueAsString(studyReq);
@@ -154,11 +156,11 @@ public class StudyControllerTest {
 
                 MockMultipartFile file = new MockMultipartFile("logo file", "logo.png", "image/png",
                                 "yourImageData".getBytes());
-                ScheduleReq scheduleUpdateReq = new ScheduleReq("없는 스케줄 이름123123", "13:00", "14:00");
+                ScheduleReq scheduleUpdateReq = new ScheduleReq("NotExistScheduleName", "13:00", "14:00");
                 List<ScheduleReq> schedules = Collections.singletonList(scheduleUpdateReq);
 
                 StudyReq studyReq = new StudyReq(
-                                "없는 스터디 이름123123", "10.10.10.110", "admin", "password", schedules);
+                                "NotExistStudyName", "10.10.10.110", "admin", "password", schedules);
                 studyReq.setSendDate(DateUtil.getCurrentDateTime());
                 studyReq.setSystemId("SYS_01");
                 String requestBodyJson = objectMapper.writeValueAsString(studyReq);
@@ -168,5 +170,28 @@ public class StudyControllerTest {
 
                 List<MockMultipartFile> files = Lists.list(file, jsonFile);
                 TestUtil.performFileRequest(mockMvc, UPDATE_STUDY_API_URL, HttpMethod.PUT, files, 200, 404);
+        }
+
+        @Test
+        @WithMockUser(username = "admin", authorities = { "ADMIN" })
+        @DisplayName("관리자 스터디 삭제 성공")
+        @Sql("/study/StudySetup.sql")
+        public void deleteStudyInfoUpdate_Success() throws Exception {
+
+                UriComponentsBuilder uriBuilder = UriComponentsBuilder
+                                .fromUriString(DELETE_STUDY_API_URL).path("/NotExistStudyName");
+
+                TestUtil.performRequest(mockMvc, uriBuilder.toUriString(), null, "DELETE", 200, 200);
+        }
+
+        @Test
+        @WithMockUser(username = "admin", authorities = { "ADMIN" })
+        @DisplayName("관리자 스터디 삭제 실패_없는 스터디 이름 삭제 시도")
+        public void deleteStudyInfoUpdate_NoExistStudyNameTried() throws Exception {
+
+                UriComponentsBuilder uriBuilder = UriComponentsBuilder
+                                .fromUriString(DELETE_STUDY_API_URL).path("/NotExistStudyName");
+
+                TestUtil.performRequest(mockMvc, uriBuilder.toUriString(), null, "DELETE", 200, 404);
         }
 }

--- a/src/test/java/mogakco/StudyManagement/controller/StudyControllerTest.java
+++ b/src/test/java/mogakco/StudyManagement/controller/StudyControllerTest.java
@@ -51,7 +51,7 @@ public class StudyControllerTest {
         private MockMvc mockMvc;
 
         private static final String CREATE_STUDY_API_URL = "/api/v1/study";
-        private static final String UPDATE_STUDY_API_URL = "/api/v1/studyinfo";
+        private static final String UPDATE_STUDY_API_URL = "/api/v1/study";
         private static final String DELETE_STUDY_API_URL = "/api/v1/study";
 
         @Test

--- a/src/test/resources/study/StudySetup.sql
+++ b/src/test/resources/study/StudySetup.sql
@@ -1,3 +1,8 @@
+INSERT INTO study.`member`
+(contact, created_at, updated_at, id, name, password, `role`)
+VALUES
+('010-1111-1111', DATE_FORMAT(NOW(6), '%Y%m%d%H%i%s%f'), DATE_FORMAT(NOW(6), '%Y%m%d%H%i%s%f'), 'user1', '사용자1', '$2a$10$khWE6krzNMGVRgpisGJmrOADrpklNtVEyGDVLJsHMb2UjyNNj7a0O', 'USER');
+
 insert into study_info(db_password, db_url, db_user, study_name, study_logo) values ('password', '10.10.110.110', 'admin', 'NotExistStudyName', null);
 
 insert into schedule(end_time, schedule_name, start_time) values('13:00','NotExistScheduleName','14:00');

--- a/src/test/resources/study/StudySetup.sql
+++ b/src/test/resources/study/StudySetup.sql
@@ -1,5 +1,5 @@
-insert into study_info(db_password, db_url, db_user, study_name, study_logo) values ('password', '10.10.110.110', 'admin', '없는 스터디 이름123123', null);
+insert into study_info(db_password, db_url, db_user, study_name, study_logo) values ('password', '10.10.110.110', 'admin', 'NotExistStudyName', null);
 
-insert into schedule(end_time, schedule_name, start_time) values('13:00','없는 스케줄 이름123123','14:00');
+insert into schedule(end_time, schedule_name, start_time) values('13:00','NotExistScheduleName','14:00');
 
 

--- a/study_create_or_update.json
+++ b/study_create_or_update.json
@@ -1,6 +1,8 @@
 {
+  "sendDate": "20240112113804899",
   "systemId": "STUDY_0001",
   "studyName": "모각코 스터디",
+  "updateStudyName": "변경할 스터디 이름",
   "schedules": [
     {
       "scheduleName": "AM2",


### PR DESCRIPTION
안녕하세요! 주요 작업 내용 하기 참조 부탁 드립니다.

<img width="1454" alt="image" src="https://github.com/ZinnaChoi/Study-Management/assets/95012623/d27cfea1-38af-4301-825c-6689baa782bf">


[feat]
1. 관리자 스터디 정보 삭제 API 개발 및 테스트 코드 작성

[refactor]
1. 관리자 스터디 정보 수정 API Endpoint 변경(/studyinfo -> /study 로 수정하여 다른 CRUD API와 통일)
2. 관리자 스터디 정보 수정 API
-> 스터디 정보 중 스케줄 수정 시 추가, 수정, 삭제가 이루어져야 하는데 삭제 로직이 빠져있어 추가하였습니다.