### PR TITLE
Task modify post detail query to include comments and reply cnt

### DIFF
--- a/src/main/java/mogakco/StudyManagement/domain/PostComment.java
+++ b/src/main/java/mogakco/StudyManagement/domain/PostComment.java
@@ -1,5 +1,8 @@
 package mogakco.StudyManagement.domain;
 
+import org.hibernate.annotations.OnDelete;
+import org.hibernate.annotations.OnDeleteAction;
+
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.FetchType;
@@ -28,10 +31,12 @@ public class PostComment {
 
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "parent_comment_id")
+    @OnDelete(action = OnDeleteAction.CASCADE)
     private PostComment parentComment;
 
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "post_id", nullable = false)
+    @OnDelete(action = OnDeleteAction.CASCADE)
     private Post post;
 
     @ManyToOne(fetch = FetchType.LAZY)

--- a/src/main/java/mogakco/StudyManagement/domain/PostLike.java
+++ b/src/main/java/mogakco/StudyManagement/domain/PostLike.java
@@ -1,5 +1,8 @@
 package mogakco.StudyManagement.domain;
 
+import org.hibernate.annotations.OnDelete;
+import org.hibernate.annotations.OnDeleteAction;
+
 import jakarta.persistence.Entity;
 import jakarta.persistence.FetchType;
 import jakarta.persistence.GeneratedValue;
@@ -26,6 +29,7 @@ public class PostLike {
     private Long likesId;
 
     @ManyToOne(fetch = FetchType.LAZY)
+    @OnDelete(action = OnDeleteAction.CASCADE)
     @JoinColumn(name = "post_id", nullable = false)
     private Post post;
 

--- a/src/main/java/mogakco/StudyManagement/dto/PostDetail.java
+++ b/src/main/java/mogakco/StudyManagement/dto/PostDetail.java
@@ -1,5 +1,7 @@
 package mogakco.StudyManagement.dto;
 
+import java.util.List;
+
 import lombok.Getter;
 import lombok.Setter;
 import mogakco.StudyManagement.domain.Post;
@@ -19,14 +21,15 @@ public class PostDetail {
 
     private String updatedAt;
 
-    public PostDetail(Post post, Integer likes) {
+    private List<PostDetailComment> comments;
 
+    public PostDetail(Post post, Integer likes, List<PostDetailComment> comments) {
         this.memberName = post.getMember().getName();
         this.title = post.getTitle();
         this.content = post.getContent();
         this.createdAt = post.getCreatedAt();
         this.updatedAt = post.getUpdatedAt();
         this.likes = likes;
-
+        this.comments = comments;
     }
 }

--- a/src/main/java/mogakco/StudyManagement/dto/PostDetailComment.java
+++ b/src/main/java/mogakco/StudyManagement/dto/PostDetailComment.java
@@ -1,0 +1,22 @@
+package mogakco.StudyManagement.dto;
+
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+public class PostDetailComment {
+
+    private Long commnetId;
+
+    private String memeberName;
+
+    private String content;
+
+    private String createdAt;
+
+    private String updatedAt;
+
+    private Integer replyCnt;
+
+}

--- a/src/main/java/mogakco/StudyManagement/repository/PostCommentRepository.java
+++ b/src/main/java/mogakco/StudyManagement/repository/PostCommentRepository.java
@@ -11,4 +11,6 @@ public interface PostCommentRepository extends JpaRepository<PostComment, Long>,
 
     Integer countByPostPostId(Long postId);
 
+    Integer countByParentCommentCommentId(Long parentCommentId);
+
 }

--- a/src/main/java/mogakco/StudyManagement/repository/PostCommentSpecification.java
+++ b/src/main/java/mogakco/StudyManagement/repository/PostCommentSpecification.java
@@ -2,11 +2,20 @@ package mogakco.StudyManagement.repository;
 
 import org.springframework.data.jpa.domain.Specification;
 
+import jakarta.persistence.criteria.Predicate;
 import mogakco.StudyManagement.domain.PostComment;
 
 public class PostCommentSpecification {
 
     public static Specification<PostComment> withCommentId(Long commentId) {
         return (root, query, criteriaBuiler) -> criteriaBuiler.equal(root.get("commentId"), commentId);
+    }
+
+    public static Specification<PostComment> withPostIdAndParentCommentIdIsNull(Long postId) {
+        return (root, query, criteriaBuilder) -> {
+            Predicate postPredicate = criteriaBuilder.equal(root.get("post").get("id"), postId);
+            Predicate parentCommentPredicate = criteriaBuilder.isNull(root.get("parentComment"));
+            return criteriaBuilder.and(postPredicate, parentCommentPredicate);
+        };
     }
 }

--- a/src/test/java/mogakco/StudyManagement/controller/PostControllerTest.java
+++ b/src/test/java/mogakco/StudyManagement/controller/PostControllerTest.java
@@ -177,7 +177,7 @@ public class PostControllerTest {
             int commentCnt = element.path("commentCnt").asInt();
             assertTrue(title.startsWith("post2"));
             assertEquals(likeCnt, 1);
-            assertEquals(commentCnt, 1);
+            assertEquals(commentCnt, 2);
             break;
         }
     }
@@ -224,7 +224,7 @@ public class PostControllerTest {
 
     @Test
     @Sql("/post/PostSetup.sql")
-    @WithMockUser(username = "PostUser", authorities = { "USER" })
+    @WithMockUser(username = "PostUser2", authorities = { "USER" })
     @DisplayName("게시글 상세 정보 조회 성공")
     public void getPostDetailSuccess() throws Exception {
 
@@ -234,6 +234,11 @@ public class PostControllerTest {
         JsonNode responseBody = objectMapper.readTree(result.getResponse().getContentAsString());
         String title = responseBody.path("postDetail").path("title").asText();
         assertTrue(title.startsWith("post"));
+
+        JsonNode comments = responseBody.path("postDetail").path("comments").get(0);
+
+        assertEquals("comment1", comments.path("content").asText());
+        assertEquals(1, comments.path("replyCnt").asInt());
     }
 
     @Test
@@ -276,7 +281,6 @@ public class PostControllerTest {
         String requestBodyJson = objectMapper.writeValueAsString(
                 new PostReq(DateUtil.getCurrentDateTime(), systemId, "Updated Title", "Updated Content"));
 
-        // Not Exist postId -1
         TestUtil.performRequest(mockMvc,
                 POST_API_URL + "/" + -1, requestBodyJson, "PATCH", 200, 404);
     }
@@ -328,7 +332,7 @@ public class PostControllerTest {
 
     public Long getLatestPostIdByMemberId(String memberId) {
         return jdbcTemplate.queryForObject(
-                "SELECT post_id FROM post WHERE member_id = (SELECT member_id FROM member WHERE id = ?) ORDER BY created_at DESC LIMIT 1",
+                "SELECT post_id FROM post WHERE member_id = (SELECT member_id FROM member WHERE id = ?) AND title = 'post2'",
                 Long.class,
                 memberId);
     }

--- a/src/test/resources/post/PostSetup.sql
+++ b/src/test/resources/post/PostSetup.sql
@@ -28,7 +28,7 @@ INSERT INTO study.post_like
 (member_id, post_id)
 VALUES
 (
-    (SELECT member_id FROM member WHERE id = 'PostUser2'),
+    (SELECT member_id FROM member WHERE id = 'PostUser'),
     (SELECT post_id FROM post WHERE title = 'post2')
 
 );
@@ -37,11 +37,24 @@ INSERT INTO study.post_comment
 ( member_id, parent_comment_id, post_id, content, created_at, updated_at)
 VALUES 
 (   
-    (SELECT member_id FROM member WHERE id = 'PostUser2'),
+    (SELECT member_id FROM member WHERE id = 'PostUser'),
     null,
     (select  post_id from post
     where title  = 'post2'),
     'comment1',
+    DATE_FORMAT(NOW(6), '%Y%m%d24%H%i%s%f'),
+    DATE_FORMAT(NOW(6), '%Y%m%d24%H%i%s%f')
+);
+
+
+INSERT INTO study.post_comment
+(member_id, parent_comment_id, post_id, content, created_at, updated_at)
+VALUES 
+(
+    (SELECT member_id FROM member WHERE id = 'PostUser'),
+    (SELECT comment_id FROM (SELECT comment_id FROM post_comment WHERE content = 'comment1') AS tmp),
+    ( SELECT post_id FROM post WHERE title = 'post2'),
+    'reply1',
     DATE_FORMAT(NOW(6), '%Y%m%d24%H%i%s%f'),
     DATE_FORMAT(NOW(6), '%Y%m%d24%H%i%s%f')
 );


### PR DESCRIPTION
안녕하세요 @dayeon-dayeon !

---
- 게시판 댓글 조회 API를 따로 생성하는 대신에, 게시글 상세 조회 시 특정 게시글에 속한 댓글들과, 각 댓글의 답글의 수를 함께 조회해오도록 게시글 상세 조회 API를 변경하였습니다

![image](https://github.com/ZinnaChoi/Study-Management/assets/142554606/4ddf37c3-f861-4bdf-ae88-5da349aba899)


- 아래와 같이 게시글의 제목, 내용, 좋아요, 작성자 등과 함께, 댓글과 댓글에 달린 답글의 수를 한 번에 가져오는 것이 API 호출의 수를 줄여줄 수 있을 것이라고 생각했습니다:

![image](https://github.com/ZinnaChoi/Study-Management/assets/142554606/1c775a3b-01d5-4875-bd28-d28a2e45f171)

- `PostControllerTest.java`에 댓글과, 답글의 수를 제대로 가져오는지 확인할 수 있도록 테스트도 업데이트 해 두었습니다
---
또한 게시글을 지울 때, 게시글에 달린 답글, 댓글 , 좋아요도 모두 지워지도록 Cascade 설정을 추가하였습니다

확인 부탁드립니다
감사합니다!! 