### PR TITLE
[refactor] Update 'javax.mail' to 'JavaMailSender'

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -33,7 +33,7 @@ dependencies {
 	implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.2.0'
 	implementation 'org.springframework.boot:spring-boot-starter-data-redis'
 	implementation 'org.springframework.boot:spring-boot-starter-batch'
-	implementation 'com.sun.mail:javax.mail:1.6.2'
+	implementation 'org.springframework.boot:spring-boot-starter-mail'
 
 	compileOnly 'org.projectlombok:lombok'
 	annotationProcessor 'org.projectlombok:lombok'

--- a/src/main/java/mogakco/StudyManagement/scheduler/StartTimeMonitoringScheduler.java
+++ b/src/main/java/mogakco/StudyManagement/scheduler/StartTimeMonitoringScheduler.java
@@ -31,7 +31,6 @@ public class StartTimeMonitoringScheduler {
     public void executeGeneralNotice() {
         try {
             noticeService.createGeneralNotice(lo);
-            System.out.println("구글 링크 생성을 위한 스케줄 모니터링 작업이 진행중입니다.");
         } catch (Exception e) {
             System.err.println("구글 링크 생성을 위한 스케줄 모니터링 작업 도중 오류가 발생했습니다: " + e.getMessage());
         }

--- a/src/main/java/mogakco/StudyManagement/service/external/SendEmailService.java
+++ b/src/main/java/mogakco/StudyManagement/service/external/SendEmailService.java
@@ -14,12 +14,8 @@ public class SendEmailService {
     @Autowired
     private JavaMailSender javaMailSender;
 
-    @Value("${email.username}")
-    private String fromEmail;
-
     public void sendEmail(String memberName, MessageType type, String toAddress) {
         SimpleMailMessage message = new SimpleMailMessage();
-        message.setFrom(fromEmail);
         message.setTo(toAddress);
         message.setSubject("안녕하세요. 모각코입니다");
         message.setText(createContent(memberName, type));

--- a/src/main/java/mogakco/StudyManagement/service/external/SendEmailService.java
+++ b/src/main/java/mogakco/StudyManagement/service/external/SendEmailService.java
@@ -1,56 +1,34 @@
 package mogakco.StudyManagement.service.external;
 
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
+import org.springframework.mail.SimpleMailMessage;
+import org.springframework.mail.javamail.JavaMailSender;
 import org.springframework.stereotype.Service;
-
-import lombok.RequiredArgsConstructor;
-import javax.mail.*;
-import javax.mail.internet.InternetAddress;
-import javax.mail.internet.MimeMessage;
-import java.util.Properties;
 
 import mogakco.StudyManagement.enums.MessageType;
 
-@RequiredArgsConstructor
 @Service
-
 public class SendEmailService {
 
-    @Value("${email.username}")
-    private String username;
+    @Autowired
+    private JavaMailSender javaMailSender;
 
-    @Value("${email.password}")
-    private String password;
+    @Value("${email.username}")
+    private String fromEmail;
 
     public void sendEmail(String memberName, MessageType type, String toAddress) {
+        SimpleMailMessage message = new SimpleMailMessage();
+        message.setFrom(fromEmail);
+        message.setTo(toAddress);
+        message.setSubject("안녕하세요. 모각코입니다");
+        message.setText(createContent(memberName, type));
 
         try {
-
-            Properties props = new Properties();
-            props.put("mail.smtp.auth", "true");
-            props.put("mail.smtp.starttls.enable", "true");
-            props.put("mail.smtp.host", "smtp.gmail.com");
-            props.put("mail.smtp.port", "587");
-
-            Authenticator authenticator = new Authenticator() {
-                protected PasswordAuthentication getPasswordAuthentication() {
-                    return new PasswordAuthentication(username, password);
-                }
-            };
-            Session session = Session.getInstance(props, authenticator);
-
-            Message message = new MimeMessage(session);
-            message.setFrom(new InternetAddress(username));
-            message.setRecipients(Message.RecipientType.TO, InternetAddress.parse(toAddress));
-            message.setSubject("안녕하세요. 모각코입니다");
-            message.setText(createContent(memberName, type));
-
-            Transport.send(message);
-
+            javaMailSender.send(message);
             System.out.println("알림 이메일이 전송되었습니다.");
-
-        } catch (MessagingException e) {
-            System.out.println("알림 이메일 전송에 실패하였습니다." + e.getMessage());
+        } catch (Exception e) {
+            System.out.println("알림 이메일 전송에 실패하였습니다. " + e.getMessage());
         }
     }
 

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -30,8 +30,12 @@ logging.level.org.hibernate.SQL=DEBUG
 logging.level.org.hibernate.type.descriptor.sql.BasicBinder=TRACE
 
 # 이메일로 알림 전송 시 사용할 다연 개인 계정. 추후에 필요시 새 계정 생성 예정 (다연) 
-email.username=wowdayeon@gmail.com
-email.password=itmytkxjlgxfltgu
+spring.mail.host=smtp.gmail.com
+spring.mail.port=587
+spring.mail.username=wowdayeon@gmail.com
+spring.mail.password=itmytkxjlgxfltgu
+spring.mail.properties.mail.smtp.auth=true
+spring.mail.properties.mail.smtp.starttls.enable=true
 
 #스케줄 시작 시간 체크 스케줄링 주기 1분(60초)
 scheduling.interval=60000

--- a/src/test/java/mogakco/StudyManagement/controller/AbsentControllerTest.java
+++ b/src/test/java/mogakco/StudyManagement/controller/AbsentControllerTest.java
@@ -23,6 +23,7 @@ import org.springframework.web.util.UriComponentsBuilder;
 import mogakco.StudyManagement.dto.AbsentReq;
 import mogakco.StudyManagement.service.absent.AbsentService;
 import mogakco.StudyManagement.service.common.LoggingService;
+import mogakco.StudyManagement.service.external.SendEmailService;
 import mogakco.StudyManagement.util.DateUtil;
 import mogakco.StudyManagement.util.TestUtil;
 
@@ -41,6 +42,9 @@ public class AbsentControllerTest {
 
     @Mock
     private LoggingService loggingService;
+
+    @Mock
+    private SendEmailService sendEmailService;
 
     @InjectMocks
     private AbsentController absentController;

--- a/src/test/java/mogakco/StudyManagement/controller/MemberControllerTest.java
+++ b/src/test/java/mogakco/StudyManagement/controller/MemberControllerTest.java
@@ -24,6 +24,7 @@ import mogakco.StudyManagement.dto.MemberInfoUpdateReq;
 import mogakco.StudyManagement.dto.MemberJoinReq;
 import mogakco.StudyManagement.dto.MemberLoginReq;
 import mogakco.StudyManagement.enums.MemberUpdateType;
+import mogakco.StudyManagement.service.external.SendEmailService;
 import mogakco.StudyManagement.service.member.impl.MemberServiceImpl;
 import mogakco.StudyManagement.util.DateUtil;
 import mogakco.StudyManagement.util.TestUtil;
@@ -40,6 +41,9 @@ public class MemberControllerTest {
 
     @Mock
     private MemberServiceImpl MemberServiceImpl;
+
+    @Mock
+    private SendEmailService sendEmailService;
 
     @InjectMocks
     private MemberController memberController;

--- a/src/test/java/mogakco/StudyManagement/controller/NoticeControllerTest.java
+++ b/src/test/java/mogakco/StudyManagement/controller/NoticeControllerTest.java
@@ -26,6 +26,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import mogakco.StudyManagement.dto.NoticeReq;
 import mogakco.StudyManagement.scheduler.StartTimeMonitoringScheduler;
 import mogakco.StudyManagement.service.common.LoggingService;
+import mogakco.StudyManagement.service.external.SendEmailService;
 import mogakco.StudyManagement.service.notice.NoticeService;
 import mogakco.StudyManagement.util.DateUtil;
 import mogakco.StudyManagement.util.TestUtil;
@@ -44,6 +45,9 @@ public class NoticeControllerTest {
 
         @Mock
         private LoggingService loggingService;
+
+        @Mock
+        private SendEmailService sendEmailService;
 
         @InjectMocks
         private NoticeController noticeController;

--- a/src/test/java/mogakco/StudyManagement/controller/PostCommentControllerTest.java
+++ b/src/test/java/mogakco/StudyManagement/controller/PostCommentControllerTest.java
@@ -20,6 +20,7 @@ import org.springframework.transaction.annotation.Transactional;
 
 import mogakco.StudyManagement.dto.PostCommentReq;
 import mogakco.StudyManagement.service.common.LoggingService;
+import mogakco.StudyManagement.service.external.SendEmailService;
 import mogakco.StudyManagement.service.post.PostCommentService;
 import mogakco.StudyManagement.util.DateUtil;
 import mogakco.StudyManagement.util.TestUtil;
@@ -39,6 +40,9 @@ public class PostCommentControllerTest {
 
         @Mock
         private LoggingService loggingService;
+
+        @Mock
+        private SendEmailService sendEmailService;
 
         @InjectMocks
         private PostCommentController postCommentController;

--- a/src/test/java/mogakco/StudyManagement/controller/PostControllerTest.java
+++ b/src/test/java/mogakco/StudyManagement/controller/PostControllerTest.java
@@ -23,6 +23,7 @@ import org.springframework.web.util.UriComponentsBuilder;
 import mogakco.StudyManagement.dto.PostReq;
 import mogakco.StudyManagement.enums.PostSearchType;
 import mogakco.StudyManagement.service.common.LoggingService;
+import mogakco.StudyManagement.service.external.SendEmailService;
 import mogakco.StudyManagement.service.post.PostService;
 import mogakco.StudyManagement.util.DateUtil;
 import mogakco.StudyManagement.util.TestUtil;
@@ -42,6 +43,9 @@ public class PostControllerTest {
 
     @Mock
     private LoggingService loggingService;
+
+    @Mock
+    private SendEmailService sendEmailService;
 
     @InjectMocks
     private PostController postController;

--- a/src/test/java/mogakco/StudyManagement/controller/PostLikeControllerTest.java
+++ b/src/test/java/mogakco/StudyManagement/controller/PostLikeControllerTest.java
@@ -16,6 +16,7 @@ import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.transaction.annotation.Transactional;
 
 import mogakco.StudyManagement.service.common.LoggingService;
+import mogakco.StudyManagement.service.external.SendEmailService;
 import mogakco.StudyManagement.service.post.PostLikeService;
 import mogakco.StudyManagement.util.TestUtil;
 
@@ -31,6 +32,9 @@ public class PostLikeControllerTest {
 
     @Mock
     private LoggingService loggignService;
+
+    @Mock
+    private SendEmailService sendEmailService;
 
     @InjectMocks
     private PostLikeController postLikeController;

--- a/src/test/java/mogakco/StudyManagement/controller/StatControllerTest.java
+++ b/src/test/java/mogakco/StudyManagement/controller/StatControllerTest.java
@@ -24,6 +24,7 @@ import mogakco.StudyManagement.dto.DTOReqCommon;
 import mogakco.StudyManagement.enums.LogType;
 import mogakco.StudyManagement.scheduler.DailyAbsentScheduler;
 import mogakco.StudyManagement.service.common.LoggingService;
+import mogakco.StudyManagement.service.external.SendEmailService;
 import mogakco.StudyManagement.service.stat.StatService;
 import mogakco.StudyManagement.util.DateUtil;
 import mogakco.StudyManagement.util.TestUtil;
@@ -47,6 +48,9 @@ public class StatControllerTest {
 
     @Mock
     private LoggingService loggingService;
+
+    @Mock
+    private SendEmailService sendEmailService;
 
     @InjectMocks
     private StatController statController;

--- a/src/test/java/mogakco/StudyManagement/controller/StudyControllerTest.java
+++ b/src/test/java/mogakco/StudyManagement/controller/StudyControllerTest.java
@@ -29,6 +29,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import mogakco.StudyManagement.dto.ScheduleReq;
 import mogakco.StudyManagement.dto.StudyReq;
 import mogakco.StudyManagement.service.common.LoggingService;
+import mogakco.StudyManagement.service.external.SendEmailService;
 import mogakco.StudyManagement.service.study.StudyService;
 import mogakco.StudyManagement.util.DateUtil;
 import mogakco.StudyManagement.util.TestUtil;
@@ -44,6 +45,9 @@ public class StudyControllerTest {
 
         @Mock
         private LoggingService loggingService;
+
+        @Mock
+        private SendEmailService sendEmailService;
 
         @InjectMocks
         private StudyController studyController;


### PR DESCRIPTION
안녕하세요!


이메일로 알림 전송 시 JavaMail API 'javax.mail'를 사용하였으나 원인 파악하지못한 import 에러가 간헐적으로 발생해, Spring 프레임워크에서 제공하는 이메일 전송을 위한 인터페이스 'JavaMailSender'로 변경했습니다.