### PR TITLE
[feat] home(Members Info) ui implement

### DIFF
--- a/src/main/frontend/src/index.js
+++ b/src/main/frontend/src/index.js
@@ -9,7 +9,7 @@ import MyPage from "./pages/my-page/MyPage";
 import NoticeBoard from "./pages/notice-board/NoticeBoard";
 import AttendanceStatistics from "./pages/study/AttendanceStatistics";
 import Management from "./pages/study/Management";
-import MembersInfo from "./pages/study/MembersInfo";
+import MembersInfo from "./pages/home/MembersInfo";
 import WakeUpSuccessRate from "./pages/study/WakeUpSuccessRate";
 import Login from "./pages/login/login";
 import Join from "./pages/join/join";

--- a/src/main/frontend/src/pages/home/MemberBySchedule.js
+++ b/src/main/frontend/src/pages/home/MemberBySchedule.js
@@ -1,0 +1,105 @@
+import React, { useState, useEffect } from "react";
+import { authClient } from "../../services/APIService";
+import Table from "../../components/Table";
+import Pagination from "../../components/Pagination";
+import "../../styles/Button.css";
+import "../../styles/NoticeBoard.css";
+import "../../styles/Home.css";
+
+// 스케줄 별 스터디원
+export default function MemberBySchedule(props) {
+  const [searchType, setSearchType] = useState("ALL");
+  const [schedules, setSchedules] = useState([]);
+  const [memberInfoBySchedule, setMemberInfoBySchedule] = useState([]);
+  const [page, setPage] = useState(0);
+  const [totalPages, setTotalPages] = useState(0);
+  const [size, setSize] = useState(10);
+
+  const getSchedules = () => {
+    authClient
+      .get("/schedules")
+      .then((response) => {
+        if (response && response.data) {
+          setSchedules(response.data?.registedSchedules);
+        }
+      })
+      .catch((error) => {
+        alert(
+          "스케줄 정보 조회 실패: " +
+            (error.response?.data.retMsg || "Unknown error")
+        );
+      });
+  };
+
+  const getMemberInfoBySchedule = () => {
+    const params = {
+      page: page,
+      size: size,
+      sort: "memberId,desc",
+      schedule: searchType === "ALL" ? null : searchType,
+    };
+    authClient
+      .get("/members/schedule-name", { params })
+      .then((response) => {
+        if (response && response.data) {
+          setMemberInfoBySchedule(response.data.members);
+          setPage(response.data.pageable.page);
+          setSize(response.data.pageable.size);
+          setTotalPages(response.data.pageable.totalPages);
+        }
+      })
+      .catch((error) => {
+        alert(
+          "스케줄 별 스터디원 조회 실패: " +
+            (error.response?.data.retMsg || "Unknown error")
+        );
+      });
+  };
+
+  // 최초 렌더링 시 한번만 실행
+  useEffect(() => {
+    getSchedules();
+  }, []);
+
+  // searchType 변경시마다 실행
+  useEffect(() => {
+    getMemberInfoBySchedule();
+  }, [searchType, page]);
+
+  const handleSchedulePageChange = (newPage) => {
+    console.log(newPage);
+    setPage(newPage);
+  };
+
+  return (
+    <React.Fragment>
+      <div className="member-info-layout">
+        <h5 className="between-field-and-select between-filter-and-table">
+          스케줄 이름
+        </h5>
+        <select
+          value={searchType}
+          onChange={(e) => setSearchType(e.target.value)}
+          className="selectAndInputBase select select-width"
+        >
+          <option value="ALL">전체</option>
+          {schedules.map((schedule) => (
+            <option key={schedule.scheduleId} value={schedule.scheduleName}>
+              {schedule.scheduleName} (
+              {`${schedule.startTime.slice(0, 2)}:${schedule.startTime.slice(
+                2
+              )}`}
+              ~{`${schedule.endTime.slice(0, 2)}:${schedule.endTime.slice(2)}`})
+            </option>
+          ))}
+        </select>
+      </div>
+      <Table columns={props.columns} contents={memberInfoBySchedule} />
+      <Pagination
+        totalPages={totalPages}
+        currentPage={page}
+        onPageChange={handleSchedulePageChange}
+      />
+    </React.Fragment>
+  );
+}

--- a/src/main/frontend/src/pages/home/MemberBySchedule.js
+++ b/src/main/frontend/src/pages/home/MemberBySchedule.js
@@ -7,13 +7,28 @@ import "../../styles/NoticeBoard.css";
 import "../../styles/Home.css";
 
 // 스케줄 별 스터디원
-export default function MemberBySchedule(props) {
+export default function MemberBySchedule() {
   const [searchType, setSearchType] = useState("ALL");
   const [schedules, setSchedules] = useState([]);
   const [memberInfoBySchedule, setMemberInfoBySchedule] = useState([]);
   const [page, setPage] = useState(0);
   const [totalPages, setTotalPages] = useState(0);
   const [size, setSize] = useState(10);
+
+  const columns = [
+    {
+      Header: "아이디",
+      accessor: "id",
+    },
+    {
+      Header: "이름",
+      accessor: "name",
+    },
+    {
+      Header: "스케줄 목록",
+      accessor: "scheduleNames",
+    },
+  ];
 
   const getSchedules = () => {
     authClient
@@ -42,6 +57,10 @@ export default function MemberBySchedule(props) {
       .get("/members/schedule-name", { params })
       .then((response) => {
         if (response && response.data) {
+          const members = response.data.members;
+          members.forEach((m, index) => {
+            members[index].scheduleNames = m.scheduleNames.toString();
+          });
           setMemberInfoBySchedule(response.data.members);
           setPage(response.data.pageable.page);
           setSize(response.data.pageable.size);
@@ -94,7 +113,7 @@ export default function MemberBySchedule(props) {
           ))}
         </select>
       </div>
-      <Table columns={props.columns} contents={memberInfoBySchedule} />
+      <Table columns={columns} contents={memberInfoBySchedule} />
       <Pagination
         totalPages={totalPages}
         currentPage={page}

--- a/src/main/frontend/src/pages/home/MemberByWakeup.js
+++ b/src/main/frontend/src/pages/home/MemberByWakeup.js
@@ -1,0 +1,100 @@
+import React, { useState, useEffect } from "react";
+import { authClient } from "../../services/APIService";
+import Table from "../../components/Table";
+import Pagination from "../../components/Pagination";
+import "../../styles/Button.css";
+import "../../styles/NoticeBoard.css";
+import "../../styles/Home.css";
+
+// 기상 시간 별 스터디원
+export default function MemberByWakeup(props) {
+  const [searchType, setSearchType] = useState("ALL");
+  const [wakeupTimes, setWakeupTimes] = useState([]);
+  const [memberInfoByWakeupTime, setMemberInfoByWakeupTime] = useState([]);
+  const [page, setPage] = useState(0);
+  const [totalPages, setTotalPages] = useState(0);
+  const [size, setSize] = useState(10);
+
+  const getWakeupTimes = () => {
+    authClient
+      .get("/wakeup-times")
+      .then((response) => {
+        if (response && response.data) {
+          setWakeupTimes(response.data?.registedWakeups);
+        }
+      })
+      .catch((error) => {
+        alert(
+          "기상시간 정보 조회 실패: " +
+            (error.response?.data.retMsg || "Unknown error")
+        );
+      });
+  };
+
+  const getMemberInfoByWakeupTime = () => {
+    const params = {
+      page: page,
+      size: size,
+      sort: "memberId,desc",
+      time: searchType === "ALL" ? null : searchType,
+    };
+    authClient
+      .get("/members/wakeup-time", { params })
+      .then((response) => {
+        if (response && response.data) {
+          setMemberInfoByWakeupTime(response.data.members);
+          setPage(response.data.pageable.page);
+          setSize(response.data.pageable.size);
+          setTotalPages(response.data.pageable.totalPages);
+        }
+      })
+      .catch((error) => {
+        alert(
+          "기상 시간 별 스터디원 조회 실패: " +
+            (error.response?.data.retMsg || "Unknown error")
+        );
+      });
+  };
+
+  // 최초 렌더링 시 한번만 실행
+  useEffect(() => {
+    getWakeupTimes();
+  }, []);
+
+  // searchType 변경시마다 실행
+  useEffect(() => {
+    getMemberInfoByWakeupTime();
+  }, [searchType, page]);
+
+  const handleWakeupPageChange = (newPage) => {
+    setPage(newPage);
+  };
+
+  return (
+    <React.Fragment>
+      <div className="member-info-layout">
+        <h5 className="between-field-and-select  between-filter-and-table">
+          기상 시간
+        </h5>
+        <select
+          value={searchType}
+          onChange={(e) => setSearchType(e.target.value)}
+          className="selectAndInputBase select select-width"
+        >
+          <option value="ALL">전체</option>
+          {wakeupTimes.map((wakeupTime, index) => (
+            <option key={index} value={wakeupTime}>
+              {`${wakeupTime.slice(0, 2)}:${wakeupTime.slice(2)}`}
+            </option>
+          ))}
+        </select>
+      </div>
+      <Table columns={props.columns} contents={memberInfoByWakeupTime} />
+      <Pagination
+        totalPages={totalPages}
+        currentPage={page}
+        onPageChange={handleWakeupPageChange}
+      />
+    </React.Fragment>
+  );
+}

--- a/src/main/frontend/src/pages/home/MemberByWakeup.js
+++ b/src/main/frontend/src/pages/home/MemberByWakeup.js
@@ -7,13 +7,28 @@ import "../../styles/NoticeBoard.css";
 import "../../styles/Home.css";
 
 // 기상 시간 별 스터디원
-export default function MemberByWakeup(props) {
+export default function MemberByWakeup() {
   const [searchType, setSearchType] = useState("ALL");
   const [wakeupTimes, setWakeupTimes] = useState([]);
   const [memberInfoByWakeupTime, setMemberInfoByWakeupTime] = useState([]);
   const [page, setPage] = useState(0);
   const [totalPages, setTotalPages] = useState(0);
   const [size, setSize] = useState(10);
+
+  const columns = [
+    {
+      Header: "아이디",
+      accessor: "id",
+    },
+    {
+      Header: "이름",
+      accessor: "name",
+    },
+    {
+      Header: "기상 시간",
+      accessor: "wakeupTime",
+    },
+  ];
 
   const getWakeupTimes = () => {
     authClient
@@ -42,7 +57,14 @@ export default function MemberByWakeup(props) {
       .get("/members/wakeup-time", { params })
       .then((response) => {
         if (response && response.data) {
-          setMemberInfoByWakeupTime(response.data.members);
+          const members = response.data.members;
+          members.forEach((m, index) => {
+            members[index].wakeupTime = `${m.wakeupTime.slice(
+              0,
+              2
+            )}:${m.wakeupTime.slice(2)}`;
+          });
+          setMemberInfoByWakeupTime(members);
           setPage(response.data.pageable.page);
           setSize(response.data.pageable.size);
           setTotalPages(response.data.pageable.totalPages);
@@ -89,7 +111,7 @@ export default function MemberByWakeup(props) {
           ))}
         </select>
       </div>
-      <Table columns={props.columns} contents={memberInfoByWakeupTime} />
+      <Table columns={columns} contents={memberInfoByWakeupTime} />
       <Pagination
         totalPages={totalPages}
         currentPage={page}

--- a/src/main/frontend/src/pages/home/MembersInfo.js
+++ b/src/main/frontend/src/pages/home/MembersInfo.js
@@ -22,17 +22,6 @@ export default function MembersInfo() {
     showButton: true,
   };
 
-  const columns = [
-    {
-      Header: "아이디",
-      accessor: "id",
-    },
-    {
-      Header: "이름",
-      accessor: "name",
-    },
-  ];
-
   const wakeupSuccess = () => {
     // TODO: 다연님 기상 체크 버튼 클릭 시 로직 작성
     alert("기상 확인 로직 구현 바랍니다.");
@@ -47,10 +36,10 @@ export default function MembersInfo() {
         </Button>
       </div>
       <hr />
-      <MemberBySchedule columns={columns} />
+      <MemberBySchedule />
       <h3>기상 시간 별 스터디원</h3>
       <hr />
-      <MemberByWakeup columns={columns} />
+      <MemberByWakeup />
 
       {/* TODO: 다이얼로그 예제, 삭제 예정임 */}
       <hr />

--- a/src/main/frontend/src/pages/home/MembersInfo.js
+++ b/src/main/frontend/src/pages/home/MembersInfo.js
@@ -1,9 +1,12 @@
 import React from "react";
 import CommonDialog from "../../components/CommonDialog";
 import { Button, TextField } from "@mui/material";
+import MemberBySchedule from "./MemberBySchedule";
+import MemberByWakeup from "./MemberByWakeup";
 import "../../styles/Button.css";
+import "../../styles/NoticeBoard.css";
 
-// 부재 일정 화면
+// 홈 화면
 export default function MembersInfo() {
   // prop 전달을 위한 변수
   const dialogProps = {
@@ -18,10 +21,38 @@ export default function MembersInfo() {
     submitEvt: doSomeAction,
     showButton: true,
   };
+
+  const columns = [
+    {
+      Header: "아이디",
+      accessor: "id",
+    },
+    {
+      Header: "이름",
+      accessor: "name",
+    },
+  ];
+
+  const wakeupSuccess = () => {
+    // TODO: 다연님 기상 체크 버튼 클릭 시 로직 작성
+    alert("기상 확인 로직 구현 바랍니다.");
+  };
+
   return (
     <React.Fragment>
-      <h1>스터디원 정보 조회 화면 - 홈(메인) 화면</h1>
-      <button>구현 시 기상 성공 버튼 추가 필요!!</button>
+      <div className="wakeup-block">
+        <h3>스케줄 별 스터디원</h3>
+        <Button className="accept-btn" type="button" onClick={wakeupSuccess}>
+          기상 체크
+        </Button>
+      </div>
+      <hr />
+      <MemberBySchedule columns={columns} />
+      <h3>기상 시간 별 스터디원</h3>
+      <hr />
+      <MemberByWakeup columns={columns} />
+
+      {/* TODO: 다이얼로그 예제, 삭제 예정임 */}
       <hr />
       <div>
         {/* 필요없는 props 경우는 전달하지 않아도 됨 */}

--- a/src/main/frontend/src/styles/Home.css
+++ b/src/main/frontend/src/styles/Home.css
@@ -1,0 +1,24 @@
+.member-info-layout {
+  display: flex;
+  justify-content: left;
+  align-items: center;
+  margin-left: 20px;
+}
+
+.between-field-and-select {
+  margin-right: 10px;
+}
+
+.between-filter-and-table {
+  margin-bottom: 0px;
+  margin-top: 0px;
+}
+
+.select-width {
+  max-width: 100px;
+}
+
+.wakeup-block {
+  display: flex;
+  justify-content: space-between;
+}

--- a/src/main/java/mogakco/StudyManagement/dto/MemberInfo.java
+++ b/src/main/java/mogakco/StudyManagement/dto/MemberInfo.java
@@ -1,14 +1,18 @@
 package mogakco.StudyManagement.dto;
 
-import lombok.AllArgsConstructor;
+import java.util.List;
+
+import lombok.Builder;
 import lombok.Getter;
 import lombok.Setter;
 
 @Getter
 @Setter
-@AllArgsConstructor
+@Builder
 public class MemberInfo {
 
     private String id;
     private String name;
+    private List<String> scheduleNames;
+    private String wakeupTime;
 }

--- a/src/main/java/mogakco/StudyManagement/service/member/impl/MemberServiceImpl.java
+++ b/src/main/java/mogakco/StudyManagement/service/member/impl/MemberServiceImpl.java
@@ -3,6 +3,7 @@ package mogakco.StudyManagement.service.member.impl;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Set;
+import java.util.TreeSet;
 import java.util.concurrent.TimeUnit;
 import java.util.stream.Collectors;
 
@@ -414,7 +415,8 @@ public class MemberServiceImpl implements MemberService, UserDetailsService {
 
         List<WakeUp> wakeUps = wakeUpRepository.findAll();
 
-        Set<String> result = wakeUps.stream().map(WakeUp::getWakeupTime).collect(Collectors.toSet());
+        Set<String> result = wakeUps.stream().map(WakeUp::getWakeupTime).sorted()
+                .collect(Collectors.toCollection(TreeSet::new));
 
         return new RegistedWakeupRes(systemId, ErrorCode.OK.getCode(), ErrorCode.OK.getMessage(), result);
     }

--- a/src/main/java/mogakco/StudyManagement/service/member/impl/MemberServiceImpl.java
+++ b/src/main/java/mogakco/StudyManagement/service/member/impl/MemberServiceImpl.java
@@ -355,7 +355,10 @@ public class MemberServiceImpl implements MemberService, UserDetailsService {
         }
 
         members.stream().map(m -> {
-            memberInfos.add(new MemberInfo(m.getId(), m.getName()));
+            List<MemberSchedule> memberSchedules = memberScheduleRepository.findAllByMember(m);
+            List<String> scheduleNames = memberSchedules.stream().map(ms -> ms.getSchedule().getScheduleName())
+                    .collect(Collectors.toList());
+            memberInfos.add(MemberInfo.builder().id(m.getId()).name(m.getName()).scheduleNames(scheduleNames).build());
             return m;
         }).collect(Collectors.toList());
 
@@ -379,7 +382,9 @@ public class MemberServiceImpl implements MemberService, UserDetailsService {
         List<Member> members = memberRepository.findAllById(ids);
 
         members.stream().map(m -> {
-            memberInfos.add(new MemberInfo(m.getId(), m.getName()));
+            WakeUp wakeUp = wakeUpRepository.findByMember(m);
+            memberInfos.add(
+                    MemberInfo.builder().id(m.getId()).name(m.getName()).wakeupTime(wakeUp.getWakeupTime()).build());
             return m;
         }).collect(Collectors.toList());
 


### PR DESCRIPTION
안녕하세요 home 화면으로 사용하고있는 스터디원 정보 조회 화면 구현 완료했습니다 상세 내역은 하기 참고 부탁 드립니다!

<img width="1283" alt="image" src="https://github.com/ZinnaChoi/Study-Management/assets/95012623/99bed056-7ff1-40a9-af92-45ea56ccc8eb">

<img width="378" alt="image" src="https://github.com/ZinnaChoi/Study-Management/assets/95012623/70351cd2-dad2-4329-8215-9a98338b92fc">

<img width="602" alt="image" src="https://github.com/ZinnaChoi/Study-Management/assets/95012623/39bd2780-5641-4965-a726-db905ed06d45">


1. 스케줄 및 기상 시간 별 스터디원 조회 화면 구현(조회 필터, 테이블, 페이징 적용)
2. 스터디원 조회화면이 홈 화면이므로 디렉토리 구조 변경(기존 study 하위에서 home 디렉토리 하위로)
3. 등록 기상 시간 조회 API에서 기상 시간 정렬하여 리턴하도록 변경
4. 다이얼로그 예제 버튼은 저 포함 다른 분들 조금 더 참고하시라고 아직 삭제하지 않았습니다. 추후 삭제 예정입니다.
5. 추후 다연님 기상 성공 API 연동을 위해 버튼 및 이벤트 함수만 만들어 두었습니다.(css는 신경쓰지 않았음)