### PR TITLE
[feat] implements join UI

### DIFF
--- a/src/main/frontend/src/pages/join/join.js
+++ b/src/main/frontend/src/pages/join/join.js
@@ -12,10 +12,9 @@ import "../../styles/Join.css";
 export default function Join() {
   const navigate = useNavigate();
   const [id, setId] = useState("");
-  const [pwd, setPwd] = useState({ password: "", showPassword: false });
-  const [confirmPwd, setConfirmPwd] = useState({
-    password: "",
-    showPassword: false,
+  const [passwords, setPasswords] = useState({
+    pwd: { value: "", show: false },
+    confirmPwd: { value: "", show: false },
   });
 
   const [schedules, setSchedules] = useState([]);
@@ -72,15 +71,21 @@ export default function Join() {
 
   const handleClickShowPassword = (val) => {
     if (val === "password") {
-      setPwd({
-        ...pwd,
-        showPassword: !pwd.showPassword,
-      });
+      setPasswords((prevPasswords) => ({
+        ...prevPasswords,
+        pwd: {
+          ...prevPasswords.pwd,
+          show: !prevPasswords.pwd.show,
+        },
+      }));
     } else if (val === "password-confirm") {
-      setConfirmPwd({
-        ...confirmPwd,
-        showPassword: !confirmPwd.showPassword,
-      });
+      setPasswords((prevPasswords) => ({
+        ...prevPasswords,
+        confirmPwd: {
+          ...prevPasswords.confirmPwd,
+          show: !prevPasswords.confirmPwd.show,
+        },
+      }));
     }
   };
 
@@ -105,15 +110,30 @@ export default function Join() {
         }
       })
       .catch(function (error) {
-        console.log(error);
+        alert(
+          "중복 아이디 확인 실패: " +
+            (error.response?.data.retMsg || "Unknown error")
+        );
       });
   };
 
   const handleChange = (prop) => (event) => {
     if (prop === "password") {
-      setPwd({ ...pwd, password: event.target.value });
+      setPasswords((prevPasswords) => ({
+        ...prevPasswords,
+        pwd: {
+          ...prevPasswords.pwd,
+          value: event.target.value,
+        },
+      }));
     } else if (prop === "password-confirm") {
-      setConfirmPwd({ ...confirmPwd, password: event.target.value });
+      setPasswords((prevPasswords) => ({
+        ...prevPasswords,
+        confirmPwd: {
+          ...prevPasswords.confirmPwd,
+          value: event.target.value,
+        },
+      }));
     }
   };
 
@@ -150,7 +170,6 @@ export default function Join() {
         }
       })
       .catch(function (error) {
-        console.log(error);
         const messages = JSON.parse(error.response?.data.retMsg);
         let message = "";
         for (let key in messages) {
@@ -216,8 +235,8 @@ export default function Join() {
                   className="input-size"
                   id="password"
                   name="password"
-                  type={pwd.showPassword ? "text" : "password"}
-                  value={pwd.password}
+                  type={passwords.pwd.show ? "text" : "password"}
+                  value={passwords.pwd.value}
                   onChange={handleChange("password")}
                   placeholder="8~16자 영문 대 소문자, 숫자, 특수문자"
                   autoComplete="current-password"
@@ -226,7 +245,7 @@ export default function Join() {
                       size="small"
                       onClick={() => handleClickShowPassword("password")}
                     >
-                      {pwd.showPassword ? (
+                      {passwords.pwd.show ? (
                         <Visibility fontSize="small" />
                       ) : (
                         <VisibilityOff fontSize="small" />
@@ -246,8 +265,8 @@ export default function Join() {
                   className="input-size"
                   id="password-confirm"
                   name="password-confirm"
-                  type={confirmPwd.showPassword ? "text" : "password"}
-                  value={confirmPwd.password}
+                  type={passwords.confirmPwd.show ? "text" : "password"}
+                  value={passwords.confirmPwd.value}
                   onChange={handleChange("password-confirm")}
                   endAdornment={
                     <Button
@@ -256,7 +275,7 @@ export default function Join() {
                         handleClickShowPassword("password-confirm")
                       }
                     >
-                      {confirmPwd.showPassword ? (
+                      {passwords.confirmPwd.show ? (
                         <Visibility fontSize="small" />
                       ) : (
                         <VisibilityOff fontSize="small" />

--- a/src/main/frontend/src/pages/join/join.js
+++ b/src/main/frontend/src/pages/join/join.js
@@ -1,9 +1,301 @@
-import React from "react";
+import React, { useState, useEffect } from "react";
+import { Button, FormControl, Input, Paper, Typography } from "@mui/material";
+import Select from "react-select";
+import { useNavigate } from "react-router-dom";
+import { client } from "../../services/APIService";
+import Visibility from "@mui/icons-material/Visibility";
+import VisibilityOff from "@mui/icons-material/VisibilityOff";
+import { menuTree } from "../../constants/constants";
+import "../../styles/Button.css";
+import "../../styles/Join.css";
 
 export default function Join() {
+  const navigate = useNavigate();
+  const [id, setId] = useState("");
+  const [pwd, setPwd] = useState({ password: "", showPassword: false });
+  const [confirmPwd, setConfirmPwd] = useState({
+    password: "",
+    showPassword: false,
+  });
+
+  const [schedules, setSchedules] = useState([]);
+  const [selectedSchedules, setSelectedSchedules] = useState([]);
+
+  const [isDuplicateChecked, setIsDuplicateChecked] = useState(false);
+
+  useEffect(() => {
+    getSchedules();
+  }, []);
+
+  const SchedulesSelect = () => {
+    return (
+      <div className="input-size">
+        <Select
+          options={schedules}
+          isMulti
+          required
+          value={selectedSchedules}
+          onChange={setSelectedSchedules}
+          placeholder="스케줄 선택"
+        />
+      </div>
+    );
+  };
+
+  const getSchedules = () => {
+    client
+      .get("/schedules")
+      .then((response) => {
+        if (response && response.data) {
+          const scheduleOptions = response.data?.registedSchedules.map(
+            (schedule) => ({
+              value: schedule.scheduleName,
+              label: `${schedule.scheduleName} (${schedule.startTime.slice(
+                0,
+                2
+              )}:${schedule.startTime.slice(2)}~${schedule.endTime.slice(
+                0,
+                2
+              )}:${schedule.endTime.slice(2)})`,
+            })
+          );
+          setSchedules(scheduleOptions);
+        }
+      })
+      .catch((error) => {
+        alert(
+          "스케줄 정보 조회 실패: " +
+            (error.response?.data.retMsg || "Unknown error")
+        );
+      });
+  };
+
+  const handleClickShowPassword = (val) => {
+    if (val === "password") {
+      setPwd({
+        ...pwd,
+        showPassword: !pwd.showPassword,
+      });
+    } else if (val === "password-confirm") {
+      setConfirmPwd({
+        ...confirmPwd,
+        showPassword: !confirmPwd.showPassword,
+      });
+    }
+  };
+
+  const checkIdDuplicated = () => {
+    if (id === null || id.length === 0) {
+      alert("아이디를 입력해주세요.");
+      return;
+    }
+    client
+      .post("/join/check-id", id)
+      .then(function (response) {
+        if (response.data?.retCode === 200) {
+          if (response.data?.duplicated) {
+            alert("이미 존재하는 아이디 입니다. \n다른 아이디를 사용해주세요.");
+            setId("");
+          } else {
+            setIsDuplicateChecked(true);
+            alert("사용 가능한 아이디 입니다.");
+          }
+        } else {
+          alert(response.data?.retMsg);
+        }
+      })
+      .catch(function (error) {
+        console.log(error);
+      });
+  };
+
+  const handleChange = (prop) => (event) => {
+    if (prop === "password") {
+      setPwd({ ...pwd, password: event.target.value });
+    } else if (prop === "password-confirm") {
+      setConfirmPwd({ ...confirmPwd, password: event.target.value });
+    }
+  };
+
+  const doJoin = (event) => {
+    event.preventDefault();
+    if (!isDuplicateChecked) {
+      alert("아이디 중복 확인을 해주세요.");
+      return;
+    }
+    const formData = new FormData(event.currentTarget);
+    let formJson = Object.fromEntries(formData.entries());
+    const password = formJson["password"];
+    const confirmPassword = formJson["password-confirm"];
+
+    if (password !== confirmPassword) {
+      alert("비밀번호가 일치하지 않습니다.");
+      return;
+    }
+
+    delete formJson["password-confirm"];
+    formJson["wakeupTime"] = formJson["wakeupTime"].split(":").join("");
+    formJson.scheduleNames = selectedSchedules.map(
+      (schedule) => schedule.value
+    );
+
+    client
+      .post("/join", formJson)
+      .then(function (response) {
+        if (response.data?.retCode === 200) {
+          alert("회원가입이 완료 되었습니다. 로그인 페이지로 이동합니다.");
+          navigate(menuTree.login.path);
+        } else {
+          alert(response.data?.retMsg);
+        }
+      })
+      .catch(function (error) {
+        console.log(error);
+        const messages = JSON.parse(error.response?.data.retMsg);
+        let message = "";
+        for (let key in messages) {
+          if (messages.hasOwnProperty(key)) {
+            message += messages[key] + "\n";
+          }
+        }
+        alert("회원 가입 실패: " + (message || "Unknown error"));
+      });
+  };
+
   return (
-    <React.Fragment>
-      <h1>회원가입 화면</h1>
-    </React.Fragment>
+    <div className="join-layout">
+      <Paper elevation={3} className="join-paper-size">
+        <Typography variant="h5" className="join-title">
+          회원가입
+        </Typography>
+        <hr />
+        <form onSubmit={doJoin}>
+          <div className="join-contents">
+            <FormControl margin="normal" required fullWidth>
+              <div className="join-content">
+                <div className="join-input-key">이름</div>
+                <Input className="input-size" id="name" name="name" autoFocus />
+              </div>
+            </FormControl>
+            <FormControl margin="normal" required fullWidth>
+              <div className="join-content">
+                <div className="join-input-key">이메일</div>
+                <Input
+                  className="input-size"
+                  id="email"
+                  name="email"
+                  type="email"
+                />
+              </div>
+            </FormControl>
+            <FormControl margin="normal" required fullWidth>
+              <div className="join-content">
+                <div className="join-input-key">아이디</div>
+                <Input
+                  className="input-size"
+                  id="id"
+                  name="id"
+                  value={id}
+                  onChange={(e) => setId(e.target.value)}
+                  endAdornment={
+                    <Button
+                      className="accept-btn"
+                      size="small"
+                      onClick={checkIdDuplicated}
+                    >
+                      중복 확인
+                    </Button>
+                  }
+                />
+              </div>
+            </FormControl>
+            <FormControl margin="normal" required fullWidth>
+              <div className="join-content">
+                <div className="join-input-key">비밀번호</div>
+                <Input
+                  className="input-size"
+                  id="password"
+                  name="password"
+                  type={pwd.showPassword ? "text" : "password"}
+                  value={pwd.password}
+                  onChange={handleChange("password")}
+                  placeholder="8~16자 영문 대 소문자, 숫자, 특수문자"
+                  autoComplete="current-password"
+                  endAdornment={
+                    <Button
+                      size="small"
+                      onClick={() => handleClickShowPassword("password")}
+                    >
+                      {pwd.showPassword ? (
+                        <Visibility fontSize="small" />
+                      ) : (
+                        <VisibilityOff fontSize="small" />
+                      )}
+                    </Button>
+                  }
+                  inputProps={{
+                    style: { fontSize: "0.8rem" },
+                  }}
+                />
+              </div>
+            </FormControl>
+            <FormControl margin="normal" required fullWidth>
+              <div className="join-content">
+                <div className="join-input-key">비밀번호 확인</div>
+                <Input
+                  className="input-size"
+                  id="password-confirm"
+                  name="password-confirm"
+                  type={confirmPwd.showPassword ? "text" : "password"}
+                  value={confirmPwd.password}
+                  onChange={handleChange("password-confirm")}
+                  endAdornment={
+                    <Button
+                      size="small"
+                      onClick={() =>
+                        handleClickShowPassword("password-confirm")
+                      }
+                    >
+                      {confirmPwd.showPassword ? (
+                        <Visibility fontSize="small" />
+                      ) : (
+                        <VisibilityOff fontSize="small" />
+                      )}
+                    </Button>
+                  }
+                />
+              </div>
+            </FormControl>
+            <FormControl margin="normal" required fullWidth>
+              <div className="join-content">
+                <div className="join-input-key">참여 스케줄</div>
+                <SchedulesSelect />
+              </div>
+            </FormControl>
+            <FormControl margin="normal" required fullWidth>
+              <div className="join-content">
+                <div className="join-input-key">기상 시간</div>
+                <Input
+                  className="input-size"
+                  id="wakeupTime"
+                  name="wakeupTime"
+                  type="time"
+                />
+              </div>
+            </FormControl>
+          </div>
+          <div className="join-row-space">
+            <Button
+              type="submit"
+              fullWidth
+              variant="contained"
+              className="cancel-btn"
+            >
+              회원 가입
+            </Button>
+          </div>
+        </form>
+      </Paper>
+    </div>
   );
 }

--- a/src/main/frontend/src/pages/my-page/MyPage.js
+++ b/src/main/frontend/src/pages/my-page/MyPage.js
@@ -230,19 +230,21 @@ export default function MyPage() {
         }
       })
       .catch(function (error) {
-        console.log(error);
-        alert(error.response?.data.retMsg);
+        alert(
+          "회원 정보 변경 실패: " +
+            (error.response?.data.retMsg || "Unknown error")
+        );
       });
   };
 
-  const doResign = () => {
+  const doWithdraw = () => {
     const isConfirm = window.confirm(
       "회원 탈퇴 시 사용자의 모든 정보가 삭제됩니다. \n정말 탈퇴하시겠습니까?"
     );
 
     if (isConfirm) {
       authClient
-        .delete("/resign")
+        .delete("/withdraw")
         .then(function (response) {
           if (response.data?.retCode === 200) {
             alert("회원 정보가 정상적으로 삭제되었습니다.");
@@ -252,21 +254,13 @@ export default function MyPage() {
           }
         })
         .catch(function (error) {
-          console.log(error);
-          alert(error.message);
+          alert("회원 탈퇴 실패: " + (error.message || "Unknown error"));
         });
     }
   };
 
   return (
     <React.Fragment>
-      {localStorage.getItem("role") !== "ADMIN" && (
-        <div className="resign-align">
-          <Button className="cancel-btn" onClick={doResign}>
-            회원 탈퇴
-          </Button>
-        </div>
-      )}
       <MyPagePaper
         paperTitle={myProfileProps.paperTitle}
         keys={myProfileProps.keys}
@@ -303,6 +297,13 @@ export default function MyPage() {
         switchClicked={handleSwitchChange}
         useSwitch={true}
       />
+      {localStorage.getItem("role") !== "ADMIN" && (
+        <div className="resign-align">
+          <Button className="cancel-btn" onClick={doWithdraw}>
+            회원 탈퇴
+          </Button>
+        </div>
+      )}
     </React.Fragment>
   );
 }

--- a/src/main/frontend/src/pages/my-page/MyPage.js
+++ b/src/main/frontend/src/pages/my-page/MyPage.js
@@ -1,6 +1,8 @@
 import React, { useState, useEffect } from "react";
 import Select from "react-select";
+import { useNavigate } from "react-router-dom";
 import { authClient } from "../../services/APIService";
+import { menuTree } from "../../constants/constants";
 import PersonIcon from "@mui/icons-material/Person";
 import EmailIcon from "@mui/icons-material/Email";
 import KeyIcon from "@mui/icons-material/Key";
@@ -11,9 +13,11 @@ import LockIcon from "@mui/icons-material/Lock";
 import MyPagePaper from "./MyPagePaper";
 import "../../styles/Button.css";
 import "../../styles/MyPage.css";
+import { Button } from "@mui/material";
 
 // 내 정보 화면
 export default function MyPage() {
+  const navigate = useNavigate();
   const [myProfileValueTitles, setMyProfileValueTitles] = useState([]);
   const [myProfileValueDescription, setMyProfileValueDescription] = useState(
     []
@@ -231,8 +235,38 @@ export default function MyPage() {
       });
   };
 
+  const doResign = () => {
+    const isConfirm = window.confirm(
+      "회원 탈퇴 시 사용자의 모든 정보가 삭제됩니다. \n정말 탈퇴하시겠습니까?"
+    );
+
+    if (isConfirm) {
+      authClient
+        .delete("/resign")
+        .then(function (response) {
+          if (response.data?.retCode === 200) {
+            alert("회원 정보가 정상적으로 삭제되었습니다.");
+            navigate(menuTree.login.path);
+          } else {
+            alert(response.data?.retMsg);
+          }
+        })
+        .catch(function (error) {
+          console.log(error);
+          alert(error.message);
+        });
+    }
+  };
+
   return (
     <React.Fragment>
+      {localStorage.getItem("role") !== "ADMIN" && (
+        <div className="resign-align">
+          <Button className="cancel-btn" onClick={doResign}>
+            회원 탈퇴
+          </Button>
+        </div>
+      )}
       <MyPagePaper
         paperTitle={myProfileProps.paperTitle}
         keys={myProfileProps.keys}

--- a/src/main/frontend/src/styles/Join.css
+++ b/src/main/frontend/src/styles/Join.css
@@ -1,0 +1,39 @@
+.join-layout {
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  min-height: 100vh;
+}
+
+.join-paper-size {
+  padding: 20px !important;
+  min-width: 400px !important;
+  max-width: 500px !important;
+}
+
+.join-row-space {
+  margin-top: 20px;
+}
+
+.join-input-key {
+  font-size: 14px !important;
+  margin-top: 5px;
+  min-width: 25%;
+}
+
+.join-content {
+  display: flex !important;
+  align-items: center !important;
+  min-width: 300px !important;
+}
+
+.join-contents {
+  margin-left: 20px;
+}
+.input-size {
+  width: 70% !important;
+}
+
+.join-title {
+  font-weight: bold !important;
+}

--- a/src/main/frontend/src/styles/MyPage.css
+++ b/src/main/frontend/src/styles/MyPage.css
@@ -40,3 +40,10 @@
   width: 35%;
   font-size: 14px;
 }
+
+.resign-align {
+  display: flex;
+  justify-content: end;
+  width: 85%;
+  margin-bottom: 20px;
+}

--- a/src/main/java/mogakco/StudyManagement/config/SecurityConfig.java
+++ b/src/main/java/mogakco/StudyManagement/config/SecurityConfig.java
@@ -40,6 +40,7 @@ public class SecurityConfig {
         http.authorizeHttpRequests((auth) -> auth
                 .requestMatchers("/", "api/v1/login", "api/v1/join", "api/v1/join/check-id")
                 .permitAll() // 회원가입, 로그인, 중복 아이디 확인은 인증 X
+                .requestMatchers(HttpMethod.GET, "api/v1/schedules").permitAll()
                 .requestMatchers("/swagger-ui.html", "/v1/api-docs/**", "/swagger-ui/**", "/swagger-resources/**")
                 .permitAll() // swagger 경로
                 // 접근 허용

--- a/src/main/java/mogakco/StudyManagement/config/SecurityConfig.java
+++ b/src/main/java/mogakco/StudyManagement/config/SecurityConfig.java
@@ -44,6 +44,8 @@ public class SecurityConfig {
                 .requestMatchers("/swagger-ui.html", "/v1/api-docs/**", "/swagger-ui/**", "/swagger-resources/**")
                 .permitAll() // swagger 경로
                 // 접근 허용
+                // 회원탈퇴는 USER만 가능
+                .requestMatchers(HttpMethod.DELETE, "/api/v1/resign").hasAuthority("USER")
                 // /api/v1/study/** 요청 중 get 메소드만 모든 권한 접근 가능
                 .requestMatchers(HttpMethod.GET, "/api/v1/study/**").hasAnyAuthority("ADMIN", "USER")
                 .requestMatchers("/api/v1/study/**").hasAuthority("ADMIN") // admin 권한만 접근 가능!

--- a/src/main/java/mogakco/StudyManagement/config/SecurityConfig.java
+++ b/src/main/java/mogakco/StudyManagement/config/SecurityConfig.java
@@ -45,7 +45,7 @@ public class SecurityConfig {
                 .permitAll() // swagger 경로
                 // 접근 허용
                 // 회원탈퇴는 USER만 가능
-                .requestMatchers(HttpMethod.DELETE, "/api/v1/resign").hasAuthority("USER")
+                .requestMatchers(HttpMethod.DELETE, "/api/v1/withdraw").hasAuthority("USER")
                 // /api/v1/study/** 요청 중 get 메소드만 모든 권한 접근 가능
                 .requestMatchers(HttpMethod.GET, "/api/v1/study/**").hasAnyAuthority("ADMIN", "USER")
                 .requestMatchers("/api/v1/study/**").hasAuthority("ADMIN") // admin 권한만 접근 가능!

--- a/src/main/java/mogakco/StudyManagement/controller/MemberController.java
+++ b/src/main/java/mogakco/StudyManagement/controller/MemberController.java
@@ -108,12 +108,12 @@ public class MemberController extends CommonController {
 
     @Operation(summary = "회원탈퇴", description = "회원탈퇴를 통해 사용자 정보 삭제")
     @SecurityRequirement(name = "bearer-key")
-    @DeleteMapping("/resign")
-    public CommonRes doResign(HttpServletRequest request) {
+    @DeleteMapping("/withdraw")
+    public CommonRes doWithDraw(HttpServletRequest request) {
         CommonRes result = new CommonRes();
 
         try {
-            result = memberService.resign();
+            result = memberService.withdraw();
         } catch (Exception e) {
             result = new CommonRes(systemId, ErrorCode.INTERNAL_ERROR.getCode(),
                     ErrorCode.INTERNAL_ERROR.getMessage());

--- a/src/main/java/mogakco/StudyManagement/controller/MemberController.java
+++ b/src/main/java/mogakco/StudyManagement/controller/MemberController.java
@@ -3,6 +3,7 @@ package mogakco.StudyManagement.controller;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Sort;
 import org.springframework.data.web.PageableDefault;
+import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -103,6 +104,21 @@ public class MemberController extends CommonController {
         }
         return result;
 
+    }
+
+    @Operation(summary = "회원탈퇴", description = "회원탈퇴를 통해 사용자 정보 삭제")
+    @SecurityRequirement(name = "bearer-key")
+    @DeleteMapping("/resign")
+    public CommonRes doResign(HttpServletRequest request) {
+        CommonRes result = new CommonRes();
+
+        try {
+            result = memberService.resign();
+        } catch (Exception e) {
+            result = new CommonRes(systemId, ErrorCode.INTERNAL_ERROR.getCode(),
+                    ErrorCode.INTERNAL_ERROR.getMessage());
+        }
+        return result;
     }
 
     @Operation(summary = "MyPage 회원 정보 조회", description = "로그인 된 회원 정보 조회")

--- a/src/main/java/mogakco/StudyManagement/domain/AbsentSchedule.java
+++ b/src/main/java/mogakco/StudyManagement/domain/AbsentSchedule.java
@@ -35,6 +35,7 @@ public class AbsentSchedule {
 
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "member_id", nullable = false)
+    @OnDelete(action = OnDeleteAction.CASCADE)
     private Member member;
 
     @ManyToOne(fetch = FetchType.LAZY)

--- a/src/main/java/mogakco/StudyManagement/domain/DailyLog.java
+++ b/src/main/java/mogakco/StudyManagement/domain/DailyLog.java
@@ -1,5 +1,8 @@
 package mogakco.StudyManagement.domain;
 
+import org.hibernate.annotations.OnDelete;
+import org.hibernate.annotations.OnDeleteAction;
+
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.EnumType;
@@ -33,6 +36,7 @@ public class DailyLog {
 
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "member_id", nullable = false)
+    @OnDelete(action = OnDeleteAction.CASCADE)
     private Member member;
 
     @Column(nullable = false)

--- a/src/main/java/mogakco/StudyManagement/domain/MemberSchedule.java
+++ b/src/main/java/mogakco/StudyManagement/domain/MemberSchedule.java
@@ -31,6 +31,7 @@ public class MemberSchedule {
 
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "member_id", nullable = false)
+    @OnDelete(action = OnDeleteAction.CASCADE)
     private Member member;
 
     @ManyToOne(fetch = FetchType.LAZY)

--- a/src/main/java/mogakco/StudyManagement/domain/Notice.java
+++ b/src/main/java/mogakco/StudyManagement/domain/Notice.java
@@ -1,6 +1,8 @@
 package mogakco.StudyManagement.domain;
 
 import org.hibernate.annotations.ColumnDefault;
+import org.hibernate.annotations.OnDelete;
+import org.hibernate.annotations.OnDeleteAction;
 
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
@@ -33,6 +35,7 @@ public class Notice {
 
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "member_id")
+    @OnDelete(action = OnDeleteAction.CASCADE)
     private Member member;
 
     @Column(name = "wakeup", nullable = false)

--- a/src/main/java/mogakco/StudyManagement/domain/Post.java
+++ b/src/main/java/mogakco/StudyManagement/domain/Post.java
@@ -34,8 +34,8 @@ public class Post {
     private Long postId;
 
     @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "member_id", nullable = false)
-    @OnDelete(action = OnDeleteAction.CASCADE)
+    @JoinColumn(name = "member_id", nullable = true)
+    @OnDelete(action = OnDeleteAction.SET_NULL)
     private Member member;
 
     @Column(length = 60, nullable = false)

--- a/src/main/java/mogakco/StudyManagement/domain/Post.java
+++ b/src/main/java/mogakco/StudyManagement/domain/Post.java
@@ -18,6 +18,9 @@ import mogakco.StudyManagement.util.DateUtil;
 
 import java.util.Objects;
 
+import org.hibernate.annotations.OnDelete;
+import org.hibernate.annotations.OnDeleteAction;
+
 @Entity
 @Builder
 @NoArgsConstructor
@@ -32,6 +35,7 @@ public class Post {
 
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "member_id", nullable = false)
+    @OnDelete(action = OnDeleteAction.CASCADE)
     private Member member;
 
     @Column(length = 60, nullable = false)

--- a/src/main/java/mogakco/StudyManagement/domain/PostComment.java
+++ b/src/main/java/mogakco/StudyManagement/domain/PostComment.java
@@ -45,6 +45,7 @@ public class PostComment {
 
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "member_id", nullable = false)
+    @OnDelete(action = OnDeleteAction.CASCADE)
     private Member member;
 
     @Column(length = 500, nullable = false)

--- a/src/main/java/mogakco/StudyManagement/domain/PostComment.java
+++ b/src/main/java/mogakco/StudyManagement/domain/PostComment.java
@@ -44,8 +44,8 @@ public class PostComment {
     private Post post;
 
     @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "member_id", nullable = false)
-    @OnDelete(action = OnDeleteAction.CASCADE)
+    @JoinColumn(name = "member_id", nullable = true)
+    @OnDelete(action = OnDeleteAction.SET_NULL)
     private Member member;
 
     @Column(length = 500, nullable = false)

--- a/src/main/java/mogakco/StudyManagement/domain/PostLike.java
+++ b/src/main/java/mogakco/StudyManagement/domain/PostLike.java
@@ -34,7 +34,7 @@ public class PostLike {
     private Post post;
 
     @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "member_id", nullable = false)
-    @OnDelete(action = OnDeleteAction.CASCADE)
+    @JoinColumn(name = "member_id", nullable = true)
+    @OnDelete(action = OnDeleteAction.SET_NULL)
     private Member member;
 }

--- a/src/main/java/mogakco/StudyManagement/domain/PostLike.java
+++ b/src/main/java/mogakco/StudyManagement/domain/PostLike.java
@@ -35,5 +35,6 @@ public class PostLike {
 
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "member_id", nullable = false)
+    @OnDelete(action = OnDeleteAction.CASCADE)
     private Member member;
 }

--- a/src/main/java/mogakco/StudyManagement/domain/WakeUp.java
+++ b/src/main/java/mogakco/StudyManagement/domain/WakeUp.java
@@ -1,5 +1,8 @@
 package mogakco.StudyManagement.domain;
 
+import org.hibernate.annotations.OnDelete;
+import org.hibernate.annotations.OnDeleteAction;
+
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.FetchType;
@@ -28,6 +31,7 @@ public class WakeUp {
 
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "member_id", nullable = false)
+    @OnDelete(action = OnDeleteAction.CASCADE)
     private Member member;
 
     @Column(nullable = false)

--- a/src/main/java/mogakco/StudyManagement/dto/PostDetail.java
+++ b/src/main/java/mogakco/StudyManagement/dto/PostDetail.java
@@ -30,7 +30,7 @@ public class PostDetail {
 
     public PostDetail(Post post, Integer likes, List<PostDetailComment> comments) {
         this.postId = post.getPostId();
-        this.memberName = post.getMember().getName();
+        this.memberName = post.getMember() == null ? "[Unknown]" : post.getMember().getName();
         this.title = post.getTitle();
         this.content = post.getContent();
         this.viewCnt = post.getViewCnt();

--- a/src/main/java/mogakco/StudyManagement/dto/PostList.java
+++ b/src/main/java/mogakco/StudyManagement/dto/PostList.java
@@ -27,7 +27,7 @@ public class PostList {
     public PostList(Post post, Integer likes, Integer commentCnt) {
         this.postId = post.getPostId();
         this.title = post.getTitle();
-        this.memberName = post.getMember().getName();
+        this.memberName = post.getMember() == null ? "[Unknown]" : post.getMember().getName();
         this.viewCnt = post.getViewCnt();
         this.createdAt = post.getCreatedAt();
         this.updatedAt = post.getUpdatedAt();

--- a/src/main/java/mogakco/StudyManagement/service/member/MemberService.java
+++ b/src/main/java/mogakco/StudyManagement/service/member/MemberService.java
@@ -25,6 +25,8 @@ public interface MemberService {
 
     CommonRes join(MemberJoinReq joinInfo);
 
+    CommonRes resign();
+
     boolean isIdDuplicated(MemberIdDuplReq idInfo);
 
     MemberInfoRes getMemberInfo();

--- a/src/main/java/mogakco/StudyManagement/service/member/MemberService.java
+++ b/src/main/java/mogakco/StudyManagement/service/member/MemberService.java
@@ -25,7 +25,7 @@ public interface MemberService {
 
     CommonRes join(MemberJoinReq joinInfo);
 
-    CommonRes resign();
+    CommonRes withdraw();
 
     boolean isIdDuplicated(MemberIdDuplReq idInfo);
 

--- a/src/main/java/mogakco/StudyManagement/service/member/impl/MemberServiceImpl.java
+++ b/src/main/java/mogakco/StudyManagement/service/member/impl/MemberServiceImpl.java
@@ -196,6 +196,22 @@ public class MemberServiceImpl implements MemberService, UserDetailsService {
     }
 
     @Override
+    @Transactional
+    public CommonRes resign() {
+        String loginUserId = SecurityUtil.getLoginUserId();
+
+        // redis에 접속한 아이디 정보가 있다면 삭제(회원 탈퇴 시 JWT 만료시키기 위함)
+        if (redisTemplate.opsForValue().get("JWT:" + loginUserId) != null) {
+            redisTemplate.delete("JWT:" + loginUserId);
+        }
+
+        Member member = memberRepository.findById(loginUserId);
+        memberRepository.delete(member);
+
+        return new CommonRes(systemId, ErrorCode.OK.getCode(), ErrorCode.OK.getMessage());
+    }
+
+    @Override
     public boolean isIdDuplicated(MemberIdDuplReq idInfo) {
 
         boolean isExist = memberRepository.existsById(idInfo.getId());

--- a/src/main/java/mogakco/StudyManagement/service/post/impl/PostServiceImpl.java
+++ b/src/main/java/mogakco/StudyManagement/service/post/impl/PostServiceImpl.java
@@ -117,7 +117,7 @@ public class PostServiceImpl extends PostCommonService implements PostService {
             List<PostDetailComment> postCommentList = commentEntities.stream().map(entity -> {
                 PostDetailComment dto = new PostDetailComment();
                 dto.setCommentId(entity.getCommentId());
-                dto.setMemberName(entity.getMember().getName());
+                dto.setMemberName(entity.getMember() == null ? "[Unknown]" : entity.getMember().getName());
                 dto.setContent(entity.getContent());
                 dto.setCreatedAt(entity.getCreatedAt());
                 dto.setUpdatedAt(entity.getUpdatedAt());

--- a/src/test/java/mogakco/StudyManagement/controller/MemberControllerTest.java
+++ b/src/test/java/mogakco/StudyManagement/controller/MemberControllerTest.java
@@ -62,6 +62,7 @@ public class MemberControllerTest {
     private static final String LOGIN_URL = "/api/v1/login";
     private static final String LOGOUT_URL = "/api/v1/logout";
     private static final String JOIN_URL = "/api/v1/join";
+    private static final String RESIGN_URL = "/api/v1/resign";
     private static final String ID_DUPLICATED_CHECK_URL = "/api/v1/join/check-id";
     private static final String MEMBER_INFO_URL = "/api/v1/member";
     private static final String MEMEBER_LIST_URL = "/api/v1/members";
@@ -158,6 +159,28 @@ public class MemberControllerTest {
         String requestBodyJson = objectMapper.writeValueAsString(req);
 
         TestUtil.performRequest(mockMvc, JOIN_URL, requestBodyJson, "POST", 400, 400);
+    }
+
+    /////////////////////////////////////////////////////////////////
+
+    @Test
+    @WithMockUser(username = "user1", authorities = { "USER" })
+    @Transactional
+    @Sql("/member/MemberSetup.sql")
+    @DisplayName("회원탈퇴 API 성공")
+    void resignSuccess() throws Exception {
+        TestUtil.performRequest(mockMvc, RESIGN_URL, null, "DELETE", 200, 200);
+    }
+
+    /////////////////////////////////////////////////////////////////
+
+    @Test
+    @WithMockUser(username = "admin", authorities = { "ADMIN" })
+    @Transactional
+    @Sql("/member/MemberSetup.sql")
+    @DisplayName("회원탈퇴 API 실패_관리자 권한")
+    void resignFail_roleAdmin() throws Exception {
+        TestUtil.performRequest(mockMvc, RESIGN_URL, null, "DELETE", 403, null);
     }
 
     /////////////////////////////////////////////////////////////////

--- a/src/test/java/mogakco/StudyManagement/controller/MemberControllerTest.java
+++ b/src/test/java/mogakco/StudyManagement/controller/MemberControllerTest.java
@@ -62,7 +62,7 @@ public class MemberControllerTest {
     private static final String LOGIN_URL = "/api/v1/login";
     private static final String LOGOUT_URL = "/api/v1/logout";
     private static final String JOIN_URL = "/api/v1/join";
-    private static final String RESIGN_URL = "/api/v1/resign";
+    private static final String WITHDRAW_URL = "/api/v1/withdraw";
     private static final String ID_DUPLICATED_CHECK_URL = "/api/v1/join/check-id";
     private static final String MEMBER_INFO_URL = "/api/v1/member";
     private static final String MEMEBER_LIST_URL = "/api/v1/members";
@@ -168,8 +168,8 @@ public class MemberControllerTest {
     @Transactional
     @Sql("/member/MemberSetup.sql")
     @DisplayName("회원탈퇴 API 성공")
-    void resignSuccess() throws Exception {
-        TestUtil.performRequest(mockMvc, RESIGN_URL, null, "DELETE", 200, 200);
+    void withdrawSuccess() throws Exception {
+        TestUtil.performRequest(mockMvc, WITHDRAW_URL, null, "DELETE", 200, 200);
     }
 
     /////////////////////////////////////////////////////////////////
@@ -179,8 +179,17 @@ public class MemberControllerTest {
     @Transactional
     @Sql("/member/MemberSetup.sql")
     @DisplayName("회원탈퇴 API 실패_관리자 권한")
-    void resignFail_roleAdmin() throws Exception {
-        TestUtil.performRequest(mockMvc, RESIGN_URL, null, "DELETE", 403, null);
+    void withdrawFail_roleAdmin() throws Exception {
+        TestUtil.performRequest(mockMvc, WITHDRAW_URL, null, "DELETE", 403, null);
+    }
+
+    /////////////////////////////////////////////////////////////////
+
+    @Test
+    @WithMockUser(username = "sajdwqe81236234", authorities = { "USER" })
+    @DisplayName("회원탈퇴 API 실패_존재하지 않는 회원 탈퇴")
+    void withdrawFail_InvalidId() throws Exception {
+        TestUtil.performRequest(mockMvc, WITHDRAW_URL, null, "DELETE", 200, 400);
     }
 
     /////////////////////////////////////////////////////////////////


### PR DESCRIPTION
@ZinnaChoi 안녕하세요 회원가입 화면 구현 완료하였습니다. 개발 상세 내용은 하기 참고 부탁 드립니다.

<img width="980" alt="image" src="https://github.com/ZinnaChoi/Study-Management/assets/95012623/8657f00e-f1df-413a-9f38-613bfc4ee515">

<img width="1211" alt="image" src="https://github.com/ZinnaChoi/Study-Management/assets/95012623/441e965d-1e4f-4906-a08c-a777dfa89f3e">


1. 회원가입 화면 개발 및 API 연동
- 등록 스케줄 목록 조회 API(/api/v1/schedules) 권한 permitAll()로 수정 -> 회원가입 시 현재 등록된 스케줄을 목록으로 제공할 수 있어야 해서 변경 하였습니다.
- 회원가입 완료 시 바로 로그인 할 수 있도록 로그인 화면으로 리다이렉팅

2. 내 정보 메뉴 내 회원탈퇴 버튼 및 회원탈퇴 API 개발 & API 테스트 코드 작성
- 회원탈퇴 API의 경우 USER 권한만 사용 가능
- 회원탈퇴 시 member_id 연관 테이블(wakeup, post, post_like, post_comment, member_schedule, absent_schedule, notice, daily_log) cascade delete 적용
- 내 정보 메뉴 내 회원탈퇴 버튼은 user 권한일 때만 표출 됨
- 회원탈퇴 완료 시 로그인 화면으로 리다이렉팅