### PR TITLE
Task add set notice

### DIFF
--- a/src/main/frontend/src/pages/my-page/MyPage.js
+++ b/src/main/frontend/src/pages/my-page/MyPage.js
@@ -26,11 +26,11 @@ export default function MyPage() {
   const [schedules, setSchedules] = useState([]);
   const [selectedSchedules, setSelectedSchedules] = useState([]);
   const [switchStates, setSwitchStates] = useState({
-    ALL: null,
-    linkShare: null,
-    absent: null,
-    wakeup: null,
-    newPost: null,
+    ALL: false,
+    linkShare: false,
+    absent: false,
+    wakeup: false,
+    newPost: false,
   });
 
   const SchedulesSelect = () => {
@@ -331,7 +331,7 @@ export default function MyPage() {
       };
 
       updatedSwitchStates.ALL = Object.values(updatedSwitchStates)
-        .slice(0, 4)
+        .slice(1)
         .every((value) => value);
     }
 

--- a/src/main/frontend/src/pages/my-page/MyPage.js
+++ b/src/main/frontend/src/pages/my-page/MyPage.js
@@ -276,7 +276,7 @@ export default function MyPage() {
 
   const getNoticeStat = () => {
     authClient
-      .get("notice/stat")
+      .get("notice")
       .then((response) => {
         if (response.data?.retCode === 200) {
           const content = response.data?.content || {};
@@ -341,7 +341,7 @@ export default function MyPage() {
 
   const updateNoticeStat = (updatedSwitchStates) => {
     authClient
-      .patch("/notice/update", updatedSwitchStates)
+      .patch("/notice", updatedSwitchStates)
       .then((response) => {
         if (response.data?.retCode === 200) {
           alert("알림 설정이 업데이트되었습니다.");

--- a/src/main/frontend/src/pages/my-page/MyPagePaper.js
+++ b/src/main/frontend/src/pages/my-page/MyPagePaper.js
@@ -36,6 +36,11 @@ export default function MyPagePaper(props) {
                       onChange={(e) =>
                         props.switchClicked(props.keys[index], e.target.checked)
                       }
+                      checked={
+                        props.useSwitch
+                          ? props.switchStates[props.keys[index]]
+                          : false
+                      }
                     />
                   ) : (
                     props.useBtn[index] &&

--- a/src/main/java/mogakco/StudyManagement/controller/NoticeController.java
+++ b/src/main/java/mogakco/StudyManagement/controller/NoticeController.java
@@ -1,7 +1,6 @@
 package mogakco.StudyManagement.controller;
 
 import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.RequestBody;
@@ -33,14 +32,14 @@ public class NoticeController extends CommonController {
     }
 
     @Operation(summary = "알림 상태 조회", description = "개인별 알림 수신 여부 상태 조회")
-    @GetMapping("/notice/{memberId}")
+    @GetMapping("/notice")
     public NoticeGetRes getNotice(
-            HttpServletRequest request, @PathVariable(name = "memberId", required = true) Long memberId) {
+            HttpServletRequest request) {
 
         NoticeGetRes result = new NoticeGetRes();
 
         try {
-            result = noticeService.getNotice(memberId);
+            result = noticeService.getNotice();
         } catch (Exception e) {
             result = new NoticeGetRes(systemId, ErrorCode.INTERNAL_ERROR.getCode(),
                     ErrorCode.INTERNAL_ERROR.getMessage(), null);
@@ -51,14 +50,12 @@ public class NoticeController extends CommonController {
 
     @Operation(summary = "알림 상태 수정", description = "개인별 알림 수신 여부 상태 수정")
     @SecurityRequirement(name = "bearer-key")
-    @PatchMapping(value = "/notice/{memberId}")
-    public CommonRes updateNotice(HttpServletRequest request,
-            @PathVariable(name = "memberId", required = true) Long memberId,
-            @RequestBody @Valid NoticeReq noticeReq) {
+    @PatchMapping(value = "/notice")
+    public CommonRes updateNotice(HttpServletRequest request, @RequestBody @Valid NoticeReq noticeReq) {
         CommonRes result = new CommonRes();
 
         try {
-            result = noticeService.updateNotice(memberId, noticeReq);
+            result = noticeService.updateNotice(noticeReq);
             result.setSystemId(systemId);
         } catch (Exception e) {
             e.printStackTrace();

--- a/src/main/java/mogakco/StudyManagement/domain/Notice.java
+++ b/src/main/java/mogakco/StudyManagement/domain/Notice.java
@@ -78,4 +78,12 @@ public class Notice {
         return this;
     }
 
+    public Notice(Member member) {
+        this.member = member;
+        this.absent = true;
+        this.lastShareDate = "0";
+        this.linkShare = true;
+        this.newPost = true;
+        this.wakeup = true;
+    }
 }

--- a/src/main/java/mogakco/StudyManagement/dto/NoticeGetRes.java
+++ b/src/main/java/mogakco/StudyManagement/dto/NoticeGetRes.java
@@ -1,11 +1,10 @@
 package mogakco.StudyManagement.dto;
 
-import java.util.List;
-
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
+import mogakco.StudyManagement.domain.Notice;
 
 @Getter
 @Setter
@@ -13,9 +12,9 @@ import lombok.Setter;
 @NoArgsConstructor
 public class NoticeGetRes extends CommonRes {
 
-    private List<NoticeList> content;
+    private Notice content;
 
-    public NoticeGetRes(String systemId, int retCode, String retMsg, List<NoticeList> content) {
+    public NoticeGetRes(String systemId, int retCode, String retMsg, Notice content) {
         super(systemId, retCode, retMsg);
         this.content = content;
 

--- a/src/main/java/mogakco/StudyManagement/repository/NoticeRepository.java
+++ b/src/main/java/mogakco/StudyManagement/repository/NoticeRepository.java
@@ -9,6 +9,7 @@ import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
+import mogakco.StudyManagement.domain.Member;
 import mogakco.StudyManagement.domain.Notice;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -16,6 +17,8 @@ import org.springframework.transaction.annotation.Transactional;
 public interface NoticeRepository extends JpaRepository<Notice, Long> {
 
     Optional<Notice> findByMember_MemberId(@Param("memberId") Long memberId);
+
+    Notice findByMember(Member member);
 
     @Transactional
     @Modifying

--- a/src/main/java/mogakco/StudyManagement/repository/NoticeRepository.java
+++ b/src/main/java/mogakco/StudyManagement/repository/NoticeRepository.java
@@ -37,4 +37,8 @@ public interface NoticeRepository extends JpaRepository<Notice, Long> {
     @Query("SELECT n.member.memberId FROM Notice n WHERE n.wakeup = true")
     List<Long> findByWakeupTrue();
 
+    @Modifying
+    default void insertNoticeForMember(Member member) {
+        save(new Notice(member));
+    }
 }

--- a/src/main/java/mogakco/StudyManagement/service/member/impl/MemberServiceImpl.java
+++ b/src/main/java/mogakco/StudyManagement/service/member/impl/MemberServiceImpl.java
@@ -44,6 +44,7 @@ import mogakco.StudyManagement.enums.ErrorCode;
 import mogakco.StudyManagement.enums.MemberRole;
 import mogakco.StudyManagement.repository.MemberRepository;
 import mogakco.StudyManagement.repository.MemberScheduleRepository;
+import mogakco.StudyManagement.repository.NoticeRepository;
 import mogakco.StudyManagement.repository.ScheduleRepository;
 import mogakco.StudyManagement.repository.StudyInfoRepository;
 import mogakco.StudyManagement.repository.WakeUpRepository;
@@ -62,6 +63,7 @@ public class MemberServiceImpl implements MemberService, UserDetailsService {
     private final WakeUpRepository wakeUpRepository;
     private final ScheduleRepository scheduleRepository;
     private final StudyInfoRepository studyInfoRepository;
+    private final NoticeRepository noticeRepository;
     private final BCryptPasswordEncoder bCryptPasswordEncoder;
     private final JWTUtil jwtUtil;
     private final RedisTemplate<String, Object> redisTemplate;
@@ -77,6 +79,7 @@ public class MemberServiceImpl implements MemberService, UserDetailsService {
             WakeUpRepository wakeUpRepository,
             ScheduleRepository scheduleRepository,
             StudyInfoRepository studyInfoRepository,
+            NoticeRepository noticeRepository,
             BCryptPasswordEncoder bCryptPasswordEncoder,
             JWTUtil jwtUtil,
             RedisTemplate<String, Object> redisTemplate) {
@@ -85,6 +88,7 @@ public class MemberServiceImpl implements MemberService, UserDetailsService {
         this.wakeUpRepository = wakeUpRepository;
         this.scheduleRepository = scheduleRepository;
         this.studyInfoRepository = studyInfoRepository;
+        this.noticeRepository = noticeRepository;
         this.bCryptPasswordEncoder = bCryptPasswordEncoder;
         this.jwtUtil = jwtUtil;
         this.redisTemplate = redisTemplate;
@@ -186,6 +190,7 @@ public class MemberServiceImpl implements MemberService, UserDetailsService {
             memberRepository.save(member);
             wakeUpRepository.save(wakeUp);
             memberScheduleRepository.saveAll(mSchedules);
+            noticeRepository.insertNoticeForMember(member);
 
         } else {
             result = new CommonRes(systemId, ErrorCode.BAD_REQUEST.getCode(),

--- a/src/main/java/mogakco/StudyManagement/service/notice/NoticeService.java
+++ b/src/main/java/mogakco/StudyManagement/service/notice/NoticeService.java
@@ -8,9 +8,9 @@ import mogakco.StudyManagement.enums.MessageType;
 
 public interface NoticeService {
 
-    NoticeGetRes getNotice(Long memberId);
+    NoticeGetRes getNotice();
 
-    CommonRes updateNotice(Long memberId, NoticeReq noticeReq);
+    CommonRes updateNotice(NoticeReq noticeReq);
 
     CommonRes createGeneralNotice();
 

--- a/src/test/java/mogakco/StudyManagement/controller/NoticeControllerTest.java
+++ b/src/test/java/mogakco/StudyManagement/controller/NoticeControllerTest.java
@@ -12,7 +12,6 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.jdbc.core.JdbcTemplate;
 import org.springframework.security.test.context.support.WithMockUser;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.context.jdbc.Sql;
@@ -53,9 +52,6 @@ public class NoticeControllerTest {
         @Autowired
         private MockMvc mockMvc;
 
-        @Autowired
-        private JdbcTemplate jdbcTemplate;
-
         @Value("${study.systemId}")
         private String systemId;
 
@@ -68,34 +64,15 @@ public class NoticeControllerTest {
         public void getNoticeListSuccess() throws Exception {
 
                 MvcResult result = TestUtil.performRequest(mockMvc,
-                                GET_NOTICE_API_URL + "/" + getMemberIdByMemberName("noticeUser1"), null, "GET", 200,
+                                GET_NOTICE_API_URL, null, "GET", 200,
                                 200);
 
                 JsonNode responseBody = objectMapper.readTree(result.getResponse().getContentAsString());
 
                 int contentCount = responseBody.path("content").size();
-                assertTrue(contentCount == 1);
+                assertTrue(contentCount >= 1);
 
         }
-
-        @Test
-        @Sql("/notice/NoticeListSetup.sql")
-        @WithMockUser(username = "noticeUser2", authorities = { "USER" })
-        @DisplayName("알림 상태 조회 실패 - 존재하지 않는 사용자 ")
-        public void getNoticeListFailForNonExistingUser() throws Exception {
-
-                TestUtil.performRequest(mockMvc, GET_NOTICE_API_URL + "/" + 5,
-                                null, "GET", 200, 404);
-
-        }
-
-        public Long getMemberIdByMemberName(String Id) {
-                return jdbcTemplate.queryForObject(
-                                "SELECT member_id FROM member WHERE id = ?",
-                                Long.class,
-                                Id);
-        }
-        /////////////////////////////////////////////////////////////////////////////////////////
 
         @Test
         @Sql("/notice/NoticeListSetup.sql")
@@ -109,7 +86,7 @@ public class NoticeControllerTest {
                                                 Boolean.FALSE, Boolean.TRUE.booleanValue()));
 
                 MvcResult result = TestUtil.performRequest(mockMvc,
-                                GET_NOTICE_API_URL + "/" + getMemberIdByMemberName("noticeUser1"), requestBodyJson,
+                                GET_NOTICE_API_URL, requestBodyJson,
                                 "PATCH", 200, 200);
                 JsonNode responseBody = objectMapper.readTree(result.getResponse().getContentAsString());
 
@@ -129,7 +106,7 @@ public class NoticeControllerTest {
                                                 Boolean.TRUE, Boolean.TRUE));
 
                 TestUtil.performRequest(mockMvc,
-                                GET_NOTICE_API_URL + "/" + getMemberIdByMemberName("noticeUser2"), requestBodyJson,
+                                GET_NOTICE_API_URL, requestBodyJson,
                                 "PATCH", 200, 204);
 
         }


### PR DESCRIPTION
안녕하세요! 
내 정보 페이지 내 알림설정입니다.




![image](https://github.com/ZinnaChoi/Study-Management/assets/73517372/cfb55942-57ce-4adb-bda1-87e1cd8e57be)




로그인한 멤버의 알림 설정 상태에 따라 스위치버튼에 표시됩니다. 

전체 버튼을 on/ off 시 전체 알림 on/off가 설정되고, 전체 버튼을 제외한 나머지 항목은 개별적으로 설정이 가능합니당





또한 기존에 멤버Id를 가지고 알림 설정 상태를 조회하던 부분을 로그인 정보를 받아오는 것으로 백엔드 수정하였습니다 !
