### PR TITLE
[feat] schedule add popup start time, end time validation apply

### DIFF
--- a/src/main/frontend/src/pages/study/StudyRegistPopup.js
+++ b/src/main/frontend/src/pages/study/StudyRegistPopup.js
@@ -1,11 +1,12 @@
 import React, { useState, useEffect } from "react";
-import { Tooltip, Chip } from "@mui/material";
+import { Tooltip, Chip, Button } from "@mui/material";
 import CommonDialog from "../../components/CommonDialog";
 import "../../styles/Dialog.css";
 import "../../styles/StudyManagement.css";
 
 export default function StudyRegistPopup(props) {
   const [addedSchedules, setAddedSchedules] = useState([]);
+  const [dialogOpen, setDialogOpen] = useState(false);
 
   useEffect(() => {
     if (props.schedules) {
@@ -33,6 +34,7 @@ export default function StudyRegistPopup(props) {
       endTime: data["종료 시간"].replace(":", ""),
     };
     setAddedSchedules((prevSchedules) => [...prevSchedules, schedule]);
+    setDialogOpen(false);
   };
 
   function isValidTime(startTime, endTime) {
@@ -54,12 +56,21 @@ export default function StudyRegistPopup(props) {
     return true;
   }
 
+  const handleOpen = () => {
+    setDialogOpen(true);
+  };
+
   const SchedulesAdd = () => {
     return (
       <div>
         <div className="dialog-content fullwidth-content">
           <div className="study-select-title">스케줄</div>
+          <Button variant="outlined" onClick={handleOpen}>
+            추가
+          </Button>
           <CommonDialog
+            open={dialogOpen}
+            closeDialog={false}
             btnTitle={"추가"}
             title={"스케줄 등록"}
             names={["스케줄 이름", "시작 시간", "종료 시간"]}
@@ -67,8 +78,9 @@ export default function StudyRegistPopup(props) {
             inputTypes={["", "time", "time"]}
             acceptStr={"추가"}
             cancleStr={"취소"}
+            onClose={() => setDialogOpen(false)}
             submitEvt={addSchedule}
-            showButton={true}
+            showButton={false}
           ></CommonDialog>
           {addedSchedules.map((as, index) => (
             <Tooltip

--- a/src/main/frontend/src/pages/study/StudyRegistPopup.js
+++ b/src/main/frontend/src/pages/study/StudyRegistPopup.js
@@ -23,6 +23,10 @@ export default function StudyRegistPopup(props) {
 
   const addSchedule = (data, event) => {
     event.stopPropagation();
+    if (!isValidTime(data["시작 시간"], data["종료 시간"])) {
+      alert("종료 시간은 시작 시간보다 이르거나 같을 수 없습니다");
+      return;
+    }
     const schedule = {
       scheduleName: data["스케줄 이름"],
       startTime: data["시작 시간"].replace(":", ""),
@@ -30,6 +34,25 @@ export default function StudyRegistPopup(props) {
     };
     setAddedSchedules((prevSchedules) => [...prevSchedules, schedule]);
   };
+
+  function isValidTime(startTime, endTime) {
+    const [sHours, sMinutes] = startTime.split(":").map(Number);
+    const [eHours, eMinutes] = endTime.split(":").map(Number);
+
+    const startDate = new Date();
+    startDate.setHours(sHours);
+    startDate.setMinutes(sMinutes);
+
+    const endDate = new Date();
+    endDate.setHours(eHours);
+    endDate.setMinutes(eMinutes);
+
+    if (endDate <= startDate) {
+      return false;
+    }
+
+    return true;
+  }
 
   const SchedulesAdd = () => {
     return (


### PR DESCRIPTION
@ZinnaChoi  안녕하세요 스케줄 추가 팝업에 시작 시간, 종료 시간 validation을 alert 창을 통해 적용 완료하였습니다.

<img width="858" alt="image" src="https://github.com/ZinnaChoi/Study-Management/assets/95012623/9dfa6a3f-85cc-48af-9074-0607a78675df">


